### PR TITLE
Pass euicc_ctx to all interface functions

### DIFF
--- a/euicc/es10x.c
+++ b/euicc/es10x.c
@@ -173,13 +173,13 @@ int es10x_init(struct euicc_ctx *ctx)
 {
     int ret;
 
-    ret = ctx->interface.apdu->connect();
+    ret = ctx->interface.apdu->connect(ctx);
     if (ret < 0)
     {
         return -1;
     }
 
-    if ((ctx->es10x_logic_channel = ctx->interface.apdu->logic_channel_open(ISD_R_AID, sizeof(ISD_R_AID) - 1)) < 0)
+    if ((ctx->es10x_logic_channel = ctx->interface.apdu->logic_channel_open(ctx, ISD_R_AID, sizeof(ISD_R_AID) - 1)) < 0)
     {
         return -1;
     }
@@ -189,7 +189,7 @@ int es10x_init(struct euicc_ctx *ctx)
 
 void es10x_fini(struct euicc_ctx *ctx)
 {
-    ctx->interface.apdu->logic_channel_close(ctx->es10x_logic_channel);
-    ctx->interface.apdu->disconnect();
+    ctx->interface.apdu->logic_channel_close(ctx, ctx->es10x_logic_channel);
+    ctx->interface.apdu->disconnect(ctx);
     ctx->es10x_logic_channel = 0;
 }

--- a/euicc/es9p.c
+++ b/euicc/es9p.c
@@ -32,7 +32,7 @@ static int es9p_trans_ex(struct euicc_ctx *ctx, const char *url, const char *url
     strcat(full_url, url_postfix);
     // printf("url: %s\n", full_url);
     // printf("tx: %s\n", str_tx);
-    if (ctx->interface.http->transmit(full_url, &rcode_mearged, &rbuf, &rlen, str_tx, strlen(str_tx)) < 0)
+    if (ctx->interface.http->transmit(ctx, full_url, &rcode_mearged, &rbuf, &rlen, str_tx, strlen(str_tx)) < 0)
     {
         goto err;
     }

--- a/euicc/euicc.h
+++ b/euicc/euicc.h
@@ -14,6 +14,7 @@ struct euicc_ctx
     uint8_t g_apdu_request_buf[256 + 8];
     uint8_t g_asn1_der_request_buf[256];
     int es10x_logic_channel;
+    void *userdata;
 };
 
 #include "es9p.h"

--- a/euicc/interface.c
+++ b/euicc/interface.c
@@ -44,7 +44,7 @@ int euicc_apdu_transmit(struct euicc_ctx *ctx, struct apdu_response *response, c
 
     memset(response, 0x00, sizeof(*response));
 
-    if (in->transmit(&response->data, &response->length, (uint8_t *)request, request_len) < 0)
+    if (in->transmit(ctx, &response->data, &response->length, (uint8_t *)request, request_len) < 0)
         return -1;
 
     if (response->length < 2)

--- a/euicc/interface.h
+++ b/euicc/interface.h
@@ -1,16 +1,18 @@
 #pragma once
 #include <inttypes.h>
 
+struct euicc_ctx;
+
 struct euicc_apdu_interface
 {
-    int (*connect)(void);
-    void (*disconnect)(void);
-    int (*logic_channel_open)(const uint8_t *aid, uint8_t aid_len);
-    void (*logic_channel_close)(uint8_t channel);
-    int (*transmit)(uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len);
+    int (*connect)(struct euicc_ctx *ctx);
+    void (*disconnect)(struct euicc_ctx *ctx);
+    int (*logic_channel_open)(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len);
+    void (*logic_channel_close)(struct euicc_ctx *ctx, uint8_t channel);
+    int (*transmit)(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len);
 };
 
 struct euicc_http_interface
 {
-    int (*transmit)(const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len);
+    int (*transmit)(struct euicc_ctx *ctx, const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len);
 };

--- a/interface/apdu/at.c
+++ b/interface/apdu/at.c
@@ -99,7 +99,7 @@ static int at_expect(char **response, const char *expected)
     return 0;
 }
 
-static int apdu_interface_connect(void)
+static int apdu_interface_connect(struct euicc_ctx *ctx)
 {
     const char *device;
 
@@ -139,14 +139,14 @@ static int apdu_interface_connect(void)
     return 0;
 }
 
-static void apdu_interface_disconnect(void)
+static void apdu_interface_disconnect(struct euicc_ctx *ctx)
 {
     fclose(fuart);
     fuart = NULL;
     logic_channel = 0;
 }
 
-static int apdu_interface_transmit(uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
 {
     int fret = 0;
     int ret;
@@ -214,7 +214,7 @@ exit:
     return fret;
 }
 
-static int apdu_interface_logic_channel_open(const uint8_t *aid, uint8_t aid_len)
+static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
 {
     char *response;
 
@@ -247,7 +247,7 @@ static int apdu_interface_logic_channel_open(const uint8_t *aid, uint8_t aid_len
     return logic_channel;
 }
 
-static void apdu_interface_logic_channel_close(uint8_t channel)
+static void apdu_interface_logic_channel_close(struct euicc_ctx *ctx, uint8_t channel)
 {
     if (!logic_channel)
     {

--- a/interface/apdu/pcsc.c
+++ b/interface/apdu/pcsc.c
@@ -154,7 +154,7 @@ static void pcsc_close(void)
     pcsc_mszReaders = NULL;
 }
 
-static int pcsc_transmit_lowlevel(uint8_t *rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int pcsc_transmit_lowlevel(uint8_t *rx, uint32_t *rx_len, const uint8_t *tx, const uint8_t tx_len)
 {
     int ret;
     DWORD rx_len_merged;
@@ -254,7 +254,7 @@ err:
     return -1;
 }
 
-static int apdu_interface_connect(void)
+static int apdu_interface_connect(struct euicc_ctx *ctx)
 {
     uint8_t rx[EUICC_INTERFACE_BUFSZ];
     uint32_t rx_len;
@@ -275,12 +275,12 @@ static int apdu_interface_connect(void)
     return 0;
 }
 
-static void apdu_interface_disconnect(void)
+static void apdu_interface_disconnect(struct euicc_ctx *ctx)
 {
     pcsc_close();
 }
 
-static int apdu_interface_transmit(uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
 {
     *rx = malloc(EUICC_INTERFACE_BUFSZ);
     if (!*rx)
@@ -300,12 +300,12 @@ static int apdu_interface_transmit(uint8_t **rx, uint32_t *rx_len, const uint8_t
     return 0;
 }
 
-static int apdu_interface_logic_channel_open(const uint8_t *aid, uint8_t aid_len)
+static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
 {
     return pcsc_logic_channel_open(aid, aid_len);
 }
 
-static void apdu_interface_logic_channel_close(uint8_t channel)
+static void apdu_interface_logic_channel_close(struct euicc_ctx *ctx, uint8_t channel)
 {
     pcsc_logic_channel_close(channel);
 }

--- a/interface/apdu/stdio.c
+++ b/interface/apdu/stdio.c
@@ -134,23 +134,23 @@ err:
     return -1;
 }
 
-static int apdu_interface_connect(void)
+static int apdu_interface_connect(struct euicc_ctx *ctx)
 {
 }
 
-static void apdu_interface_disconnect(void)
+static void apdu_interface_disconnect(struct euicc_ctx *ctx)
 {
 }
 
-static int apdu_interface_logic_channel_open(const uint8_t *aid, uint8_t aid_len)
+static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
 {
 }
 
-static void apdu_interface_logic_channel_close(uint8_t channel)
+static void apdu_interface_logic_channel_close(struct euicc_ctx *ctx, uint8_t channel)
 {
 }
 
-static int apdu_interface_transmit(uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
 {
 }
 

--- a/interface/http/curl.c
+++ b/interface/http/curl.c
@@ -72,7 +72,7 @@ static size_t http_trans_write_callback(void *contents, size_t size, size_t nmem
     return realsize;
 }
 
-static int http_interface_transmit(const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int http_interface_transmit(struct euicc_ctx *ctx, const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
 {
     int fret = 0;
     CURL *curl;

--- a/interface/http/stdio.c
+++ b/interface/http/stdio.c
@@ -230,7 +230,7 @@ exit:
 }
 
 // {"type":"http","payload":{"rcode":404,"rx":"333435"}}
-static int http_interface_transmit(const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+static int http_interface_transmit(struct euicc_ctx *ctx, const char *url, uint32_t *rcode, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
 {
     int fret = 0;
     char *rx_json;


### PR DESCRIPTION
Needed for use with JNI, when mapping Java objects to these interface structs.