### PR TITLE
feat: $PWD independent executable file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(LINUX_MINGW32)
     set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 endif()
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.8)
 project (lpac)
 
 

--- a/dlfcn-win32/dlfcn.c
+++ b/dlfcn-win32/dlfcn.c
@@ -414,8 +414,11 @@ void *dlopen( const char *file, int mode )
              * LOAD_WITH_ALTERED_SEARCH_PATH is used to make it behave more closely
              * to UNIX's search paths (start with system folders instead of current
              * folder).
+             * FIXME: Remove LOAD_WITH_ALTERED_SEARCH_PATH because it lead to Undefined
+             * Behavior and doesn't provide expected search paths.
+             * See also: https://github.com/dlfcn-win32/dlfcn-win32/issues/104
              */
-            hModule = LoadLibraryExA( lpFileName, NULL, LOAD_WITH_ALTERED_SEARCH_PATH );
+            hModule = LoadLibraryExA( lpFileName, NULL, NULL );
 
             if( !hModule )
             {

--- a/interface/http/curl.c
+++ b/interface/http/curl.c
@@ -146,7 +146,7 @@ EUICC_SHARED_EXPORT int libhttpinterface_init(struct euicc_http_interface *ifstr
     if (!(libcurl_path = getenv("LIBCURL")))
     {
 #if defined(__MINGW32__)
-        libcurl_path = ".\\libcurl.dll";
+        libcurl_path = "libcurl.dll";
 #elif defined(__APPLE__)
         libcurl_path = "libcurl.4.dylib";
 #else

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,10 @@ aux_source_directory(applet/chip DIR_LPAC_SRCS)
 aux_source_directory(applet/notification DIR_LPAC_SRCS)
 aux_source_directory(applet/profile DIR_LPAC_SRCS)
 add_executable(lpac ${DIR_LPAC_SRCS})
-set_target_properties(lpac PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
+set_target_properties(lpac PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output"
+    BUILD_RPATH "$ORIGIN"
+)
 target_link_libraries(lpac euicc)
 
 if(LINUX_MINGW32)

--- a/src/dlsym_interface.c
+++ b/src/dlsym_interface.c
@@ -12,13 +12,10 @@
 
 #if defined(__MINGW32__)
 #define INTERFACELIB_POSTFIX "dll"
-#define DIRSEP "\\"
 #elif defined(__APPLE__)
 #define INTERFACELIB_POSTFIX "dylib"
-#define DIRSEP "/"
 #else
 #define INTERFACELIB_POSTFIX "so"
-#define DIRSEP "/"
 #endif
 
 static struct applet_entry applet_apdu = {
@@ -53,12 +50,12 @@ static void dlsym_interfaces_get_path(void)
 {
     if (!(libapduinterface_path = getenv("APDU_INTERFACE")))
     {
-        libapduinterface_path = "." DIRSEP "libapduinterface_pcsc." INTERFACELIB_POSTFIX;
+        libapduinterface_path = "libapduinterface_pcsc." INTERFACELIB_POSTFIX;
     }
 
     if (!(libhttpinterface_path = getenv("HTTP_INTERFACE")))
     {
-        libhttpinterface_path = "." DIRSEP "libhttpinterface_curl." INTERFACELIB_POSTFIX;
+        libhttpinterface_path = "libhttpinterface_curl." INTERFACELIB_POSTFIX;
     }
 }
 


### PR DESCRIPTION
- Use RPATH on Linux/macOS to ensure it will search directory that contains lpac executable file.
- Windows doesnn't has RPATH, but it will search executable file directory by default. And CMake will ignore BUILD_RPATH property on Windows safely.
- BUILD_RPATH doesn't affect files after `cmake --install`, but we doesn't declare install rule now (And we use RUNTIME_OUTPUT_DIRECTORY so we actually use non-install-style). If we need install-style in future, we can set INSTALL_RPATH_USE_LINK_PATH property so CMake will ensure it will work.