### PR TITLE
chore: remove installed app field

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ lpac chip <选项> [参数]
         "global_platform_version": "2.3.0",
         "protection_profile_version": "0.0.1",
         "sas_accreditation_number": "GI-BA-UP-0419",
-        "installed_app": 0,
         "free_nvram": 295424,
         "free_ram": 295424
       }

--- a/euicc/es10cex.c
+++ b/euicc/es10cex.c
@@ -98,7 +98,6 @@ int es10cex_get_euiccinfo2(struct euicc_ctx *ctx, struct es10cex_euiccinfo2 *inf
     memcpy(info->sas_accreditation_number, asn1resp->sasAcreditationNumber.buf,
            asn1resp->sasAcreditationNumber.size);
 
-    info->installed_app = _read_ext_resource(asn1resp->extCardResource.buf, asn1resp->extCardResource.size, 0x81);
     info->free_nvram = _read_ext_resource(asn1resp->extCardResource.buf, asn1resp->extCardResource.size, 0x82);
     info->free_ram = _read_ext_resource(asn1resp->extCardResource.buf, asn1resp->extCardResource.size, 0x83);
 

--- a/euicc/es10cex.h
+++ b/euicc/es10cex.h
@@ -11,7 +11,6 @@ struct es10cex_euiccinfo2
     char global_platform_version[16];
     char sas_accreditation_number[65];
     char pp_version[16];
-    int installed_app;
     int free_nvram;
     int free_ram;
 };

--- a/src/applet/chip/info.c
+++ b/src/applet/chip/info.c
@@ -44,7 +44,6 @@ static int applet_main(int argc, char **argv)
         cJSON_AddStringToObject(jeuiccinfo2, "global_platform_version", euiccinfo2.global_platform_version);
         cJSON_AddStringToObject(jeuiccinfo2, "protection_profile_version", euiccinfo2.pp_version);
         cJSON_AddStringToObject(jeuiccinfo2, "sas_accreditation_number", euiccinfo2.sas_accreditation_number);
-        cJSON_AddNumberToObject(jeuiccinfo2, "installed_app", euiccinfo2.installed_app);
         cJSON_AddNumberToObject(jeuiccinfo2, "free_nvram", euiccinfo2.free_nvram);
         cJSON_AddNumberToObject(jeuiccinfo2, "free_ram", euiccinfo2.free_ram);
     }


### PR DESCRIPTION
> The "number of installed application" value field of extCardResource SHALL be set to '00'.

from [SGP.22 v2.5, 189p](https://www.gsma.com/esim/wp-content/uploads/2023/05/SGP.22-v2.5.pdf#page=189)

> The extCardResource field is defined in ETSI TS 102 226 [39]. This field includes the
current total available memory, expressed in bytes, for Profile download and installation.
> The "number of installed application" value field of extCardResource SHALL be set to '00'.

from [SGP.22 v3.0 (draft), 217p](https://www.gsma.com/esim/wp-content/uploads/2022/10/SGP.22-v3.0-1.pdf#page=217)