### PR TITLE
fix: RPATH in macOS, who use @loader_path instead of $ORIGIN

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,11 @@
 option(LINUX_MINGW32 "Build for windows on Linux" OFF)
 
+if(APPLE)
+    set(RPATH_BINARY_PATH "@loader_path")
+else()
+    set(RPATH_BINARY_PATH "$ORIGIN")
+endif()
+
 include_directories(.)
 aux_source_directory(. DIR_LPAC_SRCS)
 aux_source_directory(applet DIR_LPAC_SRCS)
@@ -9,7 +15,7 @@ aux_source_directory(applet/profile DIR_LPAC_SRCS)
 add_executable(lpac ${DIR_LPAC_SRCS})
 set_target_properties(lpac PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output"
-    BUILD_RPATH "$ORIGIN"
+    BUILD_RPATH "${RPATH_BINARY_PATH}"
 )
 target_link_libraries(lpac euicc)
 


### PR DESCRIPTION
All UNIX like OS use $ORIGIN except f**king macOS, who use @loader_path.

Ref: https://lekensteyn.nl/rpath.html