### PR TITLE
Fix Cygwin build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ if(CYGWIN)
     set(CMAKE_SYSTEM_NAME Windows)
     message(STATUS "Building for Cygwin")
     add_definitions(-DHAVE_TIMEGM=1)
-    add_definitions(-DWIN32)
 endif()
 
 cmake_minimum_required (VERSION 3.8)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Download:
 
 lpac is dynamic-linked, Release is built by Github action, if you can't run it you need to compile by yourself
 
+## GUI Frontend
+
+- [EasyLPAC](https://github.com/creamlike1024/EasyLPAC)
+
 # Compile
 
 <details>

--- a/interface/http/curl.c
+++ b/interface/http/curl.c
@@ -12,7 +12,7 @@
 #include <euicc/interface.h>
 
 /* BEGIN MINIMAL CURL DEFINE */
-#if defined(WIN32)
+#if defined (_WIN32) || defined (__CYGWIN__)
 #define LIBCURL_DEFAULT_PATH "libcurl.dll"
 #elif defined(__APPLE__)
 #define LIBCURL_DEFAULT_PATH "libcurl.4.dylib"

--- a/src/dlsym_interface.c
+++ b/src/dlsym_interface.c
@@ -10,7 +10,7 @@
 #include <dlfcn.h>
 #endif
 
-#if defined(WIN32)
+#if defined (_WIN32) || defined (__CYGWIN__)
 #define INTERFACELIB_EXTENSION "dll"
 #elif defined(__APPLE__)
 #define INTERFACELIB_EXTENSION "dylib"


### PR DESCRIPTION
Cygwin will not define `WIN32` and the binary built with `WIN32` defined will report an error `APDU library broken: missing libapduinterface_init`. Cygwin also does not define `_WIN32`, so check `__CYGWIN__` is defined.

For Mingw, `_WIN32` is suitable for more general situations, as `WIN32` will not be defined with some particular `-std` option
