### PR TITLE
Add GBinder backend for HIDL-based libhybris devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ make
 
 then execute `./output/lpac` to use.
 
+- Droidian
+
+Same as normal Debian/Ubuntu, however, in order to build the GBinder backends, you will need `libgbinder-dev`, `glib2.0-dev`, and you will have to set `-DLPAC_APDU_INTERFACE_GBINDER=ON` when invoking `cmake`.
+
 </details>
 
 <details>
@@ -141,6 +145,8 @@ APDU Backends:
 - `libapduinterface_at`: use AT commands interface used by LTE module
 - `libapduinterface_pcsc`: use PC/SC Smart Card API
 - `libapduinterface_stdio`: use standard input/output
+- GBinder-based backends for `libhybris` (Halium) distributions:
+  - `libapduinterface_gbinder_hidl`: use HIDL IRadio (SoC launched before Android 13)
 
 Using `libapduinterface_at` need access permission to serial port (normally `/dev/ttyUSBx`). On Arch Linux, you can add yourself to `uucp` group by `sudo usermod -aG uucp $USER`. On other distro, you may need add yourself into `dialout` group.
 

--- a/interface/apdu/CMakeLists.txt
+++ b/interface/apdu/CMakeLists.txt
@@ -33,6 +33,18 @@ if(UNIX)
     install(TARGETS apduinterface_stdio LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/lpac")
 endif()
 
+if(LPAC_APDU_INTERFACE_GBINDER)
+    add_library(apduinterface_gbinder_hidl SHARED gbinder_hidl.c)
+    target_link_libraries(apduinterface_gbinder_hidl euicc)
+    set_target_properties(apduinterface_gbinder_hidl PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
+    set_target_properties(apduinterface_gbinder_hidl PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
+    install(TARGETS apduinterface_gbinder_hidl LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/lpac")
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GBINDER REQUIRED IMPORTED_TARGET libgbinder)
+    target_link_libraries(apduinterface_gbinder_hidl PkgConfig::GBINDER)
+endif()
+
 if(CYGWIN)
     if(LPAC_APDU_INTERFACE_PCSC)
         add_custom_command(TARGET apduinterface_pcsc POST_BUILD

--- a/interface/apdu/CMakeLists.txt
+++ b/interface/apdu/CMakeLists.txt
@@ -1,3 +1,6 @@
+option(LPAC_APDU_INTERFACE_PCSC "Build PCSC backend (requires PCSC libraries)" ON)
+option(LPAC_APDU_INTERFACE_GBINDER "Build GBinder backend for libhybris devices (requires gbinder headers)" OFF)
+
 if(LPAC_APDU_INTERFACE_PCSC)
     add_library(apduinterface_pcsc SHARED pcsc.c)
     target_link_libraries(apduinterface_pcsc euicc cjson-static)

--- a/interface/apdu/CMakeLists.txt
+++ b/interface/apdu/CMakeLists.txt
@@ -1,18 +1,20 @@
-add_library(apduinterface_pcsc SHARED pcsc.c)
-target_link_libraries(apduinterface_pcsc euicc cjson-static)
-set_target_properties(apduinterface_pcsc PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
-set_target_properties(apduinterface_pcsc PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
-if(UNIX)
-    install(TARGETS apduinterface_pcsc LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/lpac")
-endif()
+if(LPAC_APDU_INTERFACE_PCSC)
+    add_library(apduinterface_pcsc SHARED pcsc.c)
+    target_link_libraries(apduinterface_pcsc euicc cjson-static)
+    set_target_properties(apduinterface_pcsc PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
+    set_target_properties(apduinterface_pcsc PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/output")
+    if(UNIX)
+        install(TARGETS apduinterface_pcsc LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}/lpac")
+    endif()
 
-if(MINGW OR CYGWIN)
-    target_link_libraries(apduinterface_pcsc winscard)
-elseif(APPLE)
-    target_link_libraries(apduinterface_pcsc "-framework PCSC")
-else()
-    find_package(PCSCLite)
-    target_link_libraries(apduinterface_pcsc PCSCLite::PCSCLite)
+    if(MINGW OR CYGWIN)
+        target_link_libraries(apduinterface_pcsc winscard)
+    elseif(APPLE)
+        target_link_libraries(apduinterface_pcsc "-framework PCSC")
+    else()
+        find_package(PCSCLite)
+        target_link_libraries(apduinterface_pcsc PCSCLite::PCSCLite)
+    endif()
 endif()
 
 add_library(apduinterface_at SHARED at.c)
@@ -32,11 +34,13 @@ if(UNIX)
 endif()
 
 if(CYGWIN)
-    add_custom_command(TARGET apduinterface_pcsc POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E rename
-            ${CMAKE_BINARY_DIR}/output/cygapduinterface_pcsc.dll ${CMAKE_BINARY_DIR}/output/libapduinterface_pcsc.dll
-        COMMAND ${CMAKE_COMMAND} -E echo
-            "Renamed ${CMAKE_BINARY_DIR}/output/cygapduinterface_pcsc.dll to ${CMAKE_BINARY_DIR}/output/libapduinterface_pcsc.dll")
+    if(LPAC_APDU_INTERFACE_PCSC)
+        add_custom_command(TARGET apduinterface_pcsc POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E rename
+                ${CMAKE_BINARY_DIR}/output/cygapduinterface_pcsc.dll ${CMAKE_BINARY_DIR}/output/libapduinterface_pcsc.dll
+            COMMAND ${CMAKE_COMMAND} -E echo
+                "Renamed ${CMAKE_BINARY_DIR}/output/cygapduinterface_pcsc.dll to ${CMAKE_BINARY_DIR}/output/libapduinterface_pcsc.dll")
+    endif()
     add_custom_command(TARGET apduinterface_at POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E rename
             ${CMAKE_BINARY_DIR}/output/cygapduinterface_at.dll ${CMAKE_BINARY_DIR}/output/libapduinterface_at.dll

--- a/interface/apdu/gbinder_hidl.c
+++ b/interface/apdu/gbinder_hidl.c
@@ -1,0 +1,306 @@
+// vim: expandtab sw=4 ts=4:
+#include <euicc/euicc.h>
+#include <euicc/hexutil.h>
+#include <euicc/interface.h>
+#include <gbinder.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DEBUG (getenv("GBINDER_APDU_DEBUG") != NULL && strcmp("true", getenv("GBINDER_APDU_DEBUG")) == 0)
+
+#define HIDL_SERVICE_DEVICE "/dev/hwbinder"
+#define HIDL_SERVICE_IFACE "android.hardware.radio@1.0::IRadio"
+#define HIDL_SERVICE_IFACE_CALLBACK "android.hardware.radio@1.0::IRadioResponse"
+
+// ref: IRadio
+#define HIDL_SERVICE_SET_RESPONSE_FUNCTIONS GBINDER_FIRST_CALL_TRANSACTION
+#define HIDL_SERVICE_ICC_OPEN_LOGICAL_CHANNEL (GBINDER_FIRST_CALL_TRANSACTION + 105)
+#define HIDL_SERVICE_ICC_CLOSE_LOGICAL_CHANNEL (GBINDER_FIRST_CALL_TRANSACTION + 106)
+#define HIDL_SERVICE_ICC_TRANSMIT_APDU_LOGICAL_CHANNEL (GBINDER_FIRST_CALL_TRANSACTION + 107)
+
+// ref: IRadioResponse
+#define HIDL_SERVICE_ICC_OPEN_LOGICAL_CHANNEL_CALLBACK (GBINDER_FIRST_CALL_TRANSACTION + 104)
+#define HIDL_SERVICE_ICC_CLOSE_LOGICAL_CHANNEL_CALLBACK (GBINDER_FIRST_CALL_TRANSACTION + 105)
+#define HIDL_SERVICE_ICC_TRANSMIT_APDU_LOGICAL_CHANNEL_CALLBACK (GBINDER_FIRST_CALL_TRANSACTION + 106)
+
+static int lastChannelId = -1;
+
+struct radio_response_info {
+    int32_t type;
+    int32_t serial;
+    int32_t error;
+};
+
+struct icc_io_result {
+    int32_t sw1;
+    int32_t sw2;
+    GBinderHidlString simResponse;
+};
+
+struct sim_apdu {
+    int32_t sessionId;
+    int32_t cla;
+    int32_t instruction;
+    int32_t p1;
+    int32_t p2;
+    int32_t p3;
+    GBinderHidlString data;
+};
+
+static const GBinderWriterField sim_apdu_f[] = {
+    GBINDER_WRITER_FIELD_HIDL_STRING(struct sim_apdu, data),
+    GBINDER_WRITER_FIELD_END()
+};
+
+static const GBinderWriterType sim_apdu_t = {
+    GBINDER_WRITER_STRUCT_NAME_AND_SIZE(struct sim_apdu), sim_apdu_f
+};
+
+static GBinderServiceManager *sm;
+// IRadioResponse
+static GBinderLocalObject *response_callback;
+// IRadio
+static GBinderRemoteObject *remote;
+static GBinderClient *client;
+
+static GMainLoop *binder_loop;
+
+static int lastIntResp = -1;
+static int lastRadioErr = 0;
+static struct icc_io_result lastIccIoResult = {0};
+
+static GBinderLocalReply *radio_response_transact(
+        GBinderLocalObject *obj,
+        GBinderRemoteRequest *req,
+        guint code, guint flags, int *status, void *user_data)
+{
+    GBinderReader reader;
+
+    gbinder_remote_request_init_reader(req, &reader);
+    const struct radio_response_info *resp =
+        gbinder_reader_read_hidl_struct(&reader, struct radio_response_info);
+    lastRadioErr = resp->error;
+
+    if (lastRadioErr != 0)
+        goto out;
+
+    switch (code) {
+        case HIDL_SERVICE_ICC_OPEN_LOGICAL_CHANNEL_CALLBACK:
+            gbinder_reader_read_int32(&reader, &lastIntResp);
+            break;
+        case HIDL_SERVICE_ICC_TRANSMIT_APDU_LOGICAL_CHANNEL_CALLBACK:
+            const struct icc_io_result *icc_io_res = gbinder_reader_read_hidl_struct(&reader, struct icc_io_result);
+            // We cannot rely on the *req pointer being valid after we return
+            memcpy(&lastIccIoResult, icc_io_res, sizeof(struct icc_io_result));
+            break;
+    }
+
+out:
+    g_main_loop_quit(binder_loop);
+    return NULL;
+}
+
+static void cleanup_channel(int id)
+{
+    GBinderLocalRequest *req = gbinder_client_new_request(client);
+    GBinderWriter writer;
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_int32(&writer, 1000);
+    gbinder_writer_append_int32(&writer, id);
+    gbinder_client_transact_sync_oneway(client, HIDL_SERVICE_ICC_CLOSE_LOGICAL_CHANNEL, req);
+    gbinder_local_request_unref(req);
+    g_main_loop_run(binder_loop);
+}
+
+static void cleanup(void)
+{
+    if (lastChannelId != -1) {
+        fprintf(stderr, "Cleaning up leaked APDU channel %d\n", lastChannelId);
+        cleanup_channel(lastChannelId);
+        lastChannelId = -1;
+    }
+}
+
+static void sighandler(int sig)
+{
+    // This would trigger atexit() hooks
+    exit(0);
+}
+
+static int try_open_slot(int slotId, const uint8_t *aid, uint32_t aid_len)
+{
+    // First, try to connect to the HIDL service for this slot
+    char fqname[255];
+    snprintf(fqname, 255, "%s/slot%d", HIDL_SERVICE_IFACE, slotId);
+    fprintf(stderr, "Attempting to connect to %s\n", fqname);
+
+    int status = 0;
+    sm = gbinder_servicemanager_new(HIDL_SERVICE_DEVICE);
+    remote = gbinder_remote_object_ref(
+            gbinder_servicemanager_get_service_sync(sm, fqname, &status));
+    client = gbinder_client_new(remote, HIDL_SERVICE_IFACE);
+
+    if (!client) {
+        fprintf(stderr, "Failed to connect to IRadio\n");
+        gbinder_client_unref(client);
+        gbinder_remote_object_unref(remote);
+        gbinder_servicemanager_unref(sm);
+        return -1;
+    }
+
+    response_callback = gbinder_servicemanager_new_local_object(
+            sm, HIDL_SERVICE_IFACE_CALLBACK, radio_response_transact, NULL);
+
+    GBinderLocalRequest *req = gbinder_client_new_request(client);
+    GBinderWriter writer;
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_local_object(&writer, response_callback);
+    gbinder_writer_append_local_object(&writer, NULL);
+    gbinder_client_transact_sync_reply(client, HIDL_SERVICE_SET_RESPONSE_FUNCTIONS, req, &status);
+    gbinder_local_request_unref(req);
+
+    if (status < 0) {
+        fprintf(stderr, "Failed to call IRadio::setResponseFunctions");
+        return -1;
+    }
+
+    // Now, try to open the AID
+    uint8_t aid_hex[255];
+    euicc_hexutil_bin2hex(aid_hex, 255, aid, aid_len);
+
+    req = gbinder_client_new_request(client);
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_int32(&writer, 1000);
+    gbinder_writer_append_hidl_string_copy(&writer, aid_hex);
+    gbinder_writer_append_int32(&writer, 0);
+    status = gbinder_client_transact_sync_oneway(client, HIDL_SERVICE_ICC_OPEN_LOGICAL_CHANNEL, req);
+    gbinder_local_request_unref(req);
+
+    if (status < 0) {
+        fprintf(stderr, "Failed to call IRadio::iccOpenLogicalChannel: %d\n", status);
+        return status;
+    }
+
+    g_main_loop_run(binder_loop);
+
+    if (lastRadioErr != 0) {
+        fprintf(stderr, "Failed to open APDU logical channel: %d\n", lastRadioErr);
+        return -lastRadioErr;
+    }
+    fprintf(stderr, "opened logical channel id: %d\n", lastIntResp);
+
+    return lastIntResp;
+}
+
+static int apdu_interface_connect(struct euicc_ctx *ctx)
+{
+    return 0;
+}
+
+static void apdu_interface_disconnect(struct euicc_ctx *ctx)
+{
+    cleanup();
+}
+
+static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
+{
+    // We only start to use gbinder connection here, because only now can we detect whether
+    // a given slot is a valid eSIM slot. This way we can automatically fall back in the case
+    // where a device has only one eSIM -- we don't want to force the user to choose in this case.
+    int res = try_open_slot(1, aid, aid_len);
+    if (res < 0)
+        res = try_open_slot(2, aid, aid_len);
+    if (res >= 0)
+        lastChannelId = res;
+    return res;
+}
+
+static void apdu_interface_logic_channel_close(struct euicc_ctx *ctx, uint8_t channel)
+{
+    cleanup_channel(channel);
+    if (lastChannelId == channel)
+        lastChannelId = -1;
+
+    // Only do this cleanup here, because on exit these objects will be destroyed anyway
+    gbinder_client_unref(client);
+    gbinder_remote_object_unref(remote);
+    gbinder_servicemanager_unref(sm);
+}
+
+static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *rx_len, const uint8_t *tx, uint32_t tx_len)
+{
+    GBinderLocalRequest *req = gbinder_client_new_request(client);
+    GBinderWriter writer;
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_int32(&writer, 1000);
+
+    uint8_t tx_hex[4096] = {0};
+    euicc_hexutil_bin2hex(tx_hex, 4096, &tx[5], tx_len - 5);
+
+    if (DEBUG)
+        fprintf(stderr, "APDU req: %s\n", tx_hex);
+
+    struct sim_apdu apdu = {
+        .sessionId = lastChannelId,
+        .cla = tx[0],
+        .instruction = tx[1],
+        .p1 = tx[2],
+        .p2 = tx[3],
+        .p3 = tx[4],
+        .data = {
+            .data = {
+                .str = (const char *) tx_hex
+            },
+            .len = strlen(tx_hex) + 1,
+            .owns_buffer = FALSE,
+        },
+    };
+    gbinder_writer_append_struct(&writer, &apdu, &sim_apdu_t, NULL);
+    int status = gbinder_client_transact_sync_oneway(client, HIDL_SERVICE_ICC_TRANSMIT_APDU_LOGICAL_CHANNEL, req);
+    gbinder_local_request_unref(req);
+
+    if (status < 0) {
+        fprintf(stderr, "Failed to call IRadio::iccTransmitApduLogicalChannel: %d\n", status);
+        return status;
+    }
+
+    g_main_loop_run(binder_loop);
+
+    if (lastRadioErr != 0) {
+        return -lastRadioErr;
+    }
+
+    if (DEBUG)
+        fprintf(stderr, "APDU resp: %d%d %d %s\n", lastIccIoResult.sw1, lastIccIoResult.sw2, lastIccIoResult.simResponse.len, lastIccIoResult.simResponse.data.str);
+
+    *rx_len = lastIccIoResult.simResponse.len / 2 + 2;
+    *rx = calloc(*rx_len, sizeof(uint8_t));
+    euicc_hexutil_hex2bin_r(*rx, *rx_len, lastIccIoResult.simResponse.data.str, lastIccIoResult.simResponse.len);
+    (*rx)[*rx_len - 2] = lastIccIoResult.sw1;
+    (*rx)[*rx_len - 1] = lastIccIoResult.sw2;
+
+    return 0;
+}
+
+EUICC_SHARED_EXPORT int libapduinterface_init(struct euicc_apdu_interface *ifstruct)
+{
+    ifstruct->connect = apdu_interface_connect;
+    ifstruct->disconnect = apdu_interface_disconnect;
+    ifstruct->logic_channel_open = apdu_interface_logic_channel_open;
+    ifstruct->logic_channel_close = apdu_interface_logic_channel_close;
+    ifstruct->transmit = apdu_interface_transmit;
+
+    // Install cleanup routine
+    atexit(cleanup);
+    signal(SIGINT, sighandler);
+
+    // The glib loop is detached from any client object, so create it here.
+    binder_loop = g_main_loop_new(NULL, FALSE);
+
+    return 0;
+}
+
+EUICC_SHARED_EXPORT int libapduinterface_main(int argc, char **argv)
+{
+    return 0;
+}


### PR DESCRIPTION
This allows users of distributions like Droidian (which uses Android HALs to run GNU/Linux userspace) to manage eSIMs directly on device.

Currently only the HIDL version is implemented, which covers all SoCs released before Android 13. Newer device will require a different AIDL implementation.

As part of this change, the PCSC backend is now also made optional but enabled by default. PCSC can be disabled with `-DLPAC_APDU_INTERFACE_PCSC=OFF`, and GBinder can be enabled with `-DLPAC_APDU_INTERFACE_GBINDER=ON`.