### PR TITLE
Add `-r` option to `notification process`

### DIFF
--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -16,16 +16,17 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printf("Usage: %s <seqNumber> [autoremove]\n", argv[0]);
-        printf("\t[autoremove]: optional\n");
+        printf("Usage: %s <seqNumber> [-r]\n", argv[0]);
+        printf("Options:\n");
+        printf("\t-r\tAutomatically remove processed notifications:\n");
         return -1;
     }
 
     seqNumber = atol(argv[1]);
     autoremove = 0;
     if (argc > 2)
-    {
-        autoremove = atoi(argv[2]);
+    {   
+        autoremove = strcmp(argv[2], "-r") == 0;
     }
 
     jprint_progress("es10b_retrieve_notifications_list");

--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -18,7 +18,7 @@ static int applet_main(int argc, char **argv)
     {
         printf("Usage: %s <seqNumber> [-r]\n", argv[0]);
         printf("Options:\n");
-        printf("\t-r\tAutomatically remove processed notifications:\n");
+        printf("\t-r\tAutomatically remove processed notifications\n");
         return -1;
     }
 


### PR DESCRIPTION
Thanks for the great project, I found it very useful.

One minor problem I found while using the `notification process` function is that `autoremove` seem to not very well-documented, have to read the source code to figure out it takes an integer.

This PR added `-r` option and a short helper message to make it clearer, following regular Unix CLI syntax.

example:
```
output % ./lpac notification          
Usage: notification <list|process|remove>
zhongyangxia@Zhongyangs-MacBook-Air output % ./lpac notification process
Usage: process <seqNumber> [-r]
Options:
	-r	Automatically remove processed notifications
```

Thanks