### PR TITLE
feat: Allow libeuicc to be installed as a dynamic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.8)
 project (lpac
-    VERSION 1.0.0
+    VERSION 1.0.1
     HOMEPAGE_URL "https://github.com/estkme-group/lpac"
     DESCRIPTION "C-based eUICC LPA."
     LANGUAGES C)

--- a/euicc/CMakeLists.txt
+++ b/euicc/CMakeLists.txt
@@ -1,4 +1,26 @@
+option(LPAC_DYNAMIC_LIBEUICC "Build and install libeuicc as a dynamic library" OFF)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} LIB_EUICC_SRCS)
-add_library(euicc STATIC ${LIB_EUICC_SRCS})
+if(LPAC_DYNAMIC_LIBEUICC)
+    add_library(euicc SHARED ${LIB_EUICC_SRCS})
+else()
+    add_library(euicc STATIC ${LIB_EUICC_SRCS})
+endif()
 target_link_libraries(euicc cjson-static)
 target_include_directories(euicc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+if(LPAC_DYNAMIC_LIBEUICC)
+    # Install headers
+    file(GLOB ALL_HEADERS "*.h")
+    foreach(header ${ALL_HEADERS})
+        if(${header} MATCHES "^.*\.private\.h$")
+            list(REMOVE_ITEM ALL_HEADERS ${header})
+        endif()
+    endforeach()
+    set_target_properties(euicc PROPERTIES PUBLIC_HEADER "${ALL_HEADERS}")
+    # Install a pkg-config file
+    configure_file(libeuicc.pc.in libeuicc.pc @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libeuicc.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    # Configure libeuicc.so installation
+    set_target_properties(euicc PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+    install(TARGETS euicc LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                          PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/euicc)
+endif()

--- a/euicc/libeuicc.pc.in
+++ b/euicc/libeuicc.pc.in
@@ -1,0 +1,10 @@
+prefix="@CMAKE_INSTALL_PREFIX@"
+exec_prefix="${prefix}"
+libdir="${prefix}/lib"
+includedir="${prefix}/include"
+
+Name: libeuicc
+Description: Library to manipuate eUICC (eSIM) cards
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -leuicc


### PR DESCRIPTION
...based on option LPAC_DYNAMIC_LIBEUICC, defaults to OFF.

This makes it possible to use libeuicc on Linux without submoduling.

Note that this would require any future breaking change to increment the MAJOR version of the project in the main CMakeLists.txt. This version number is now a public interface and must be maintained.

As part of this commit, I have modified the version code in CMakeLists to match the current release version.