### PR TITLE
feat: add ES10b#GetRAT Support

### DIFF
--- a/euicc/es10b.c
+++ b/euicc/es10b.c
@@ -1309,8 +1309,8 @@ int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList)
                                 switch (n_operator.tag)
                                 {
                                     case 0x80: // mcc_mnc
-                                        p->mcc_mnc = malloc((n_operator.length * 2) + 1);
-                                        euicc_hexutil_bin2hex(p->mcc_mnc, sizeof(p->mcc_mnc), n_operator.value, n_operator.length);
+                                        p->plmn = malloc((n_operator.length * 2) + 1);
+                                        euicc_hexutil_bin2hex(p->plmn, sizeof(p->plmn), n_operator.value, n_operator.length);
                                         break;
                                     case 0x81: // gid1
                                         p->gid1 = malloc((n_operator.length * 2) + 1);
@@ -1388,7 +1388,7 @@ void es10b_operation_id_free_all(const struct es10b_operation_id *operations) {
     while (operations)
     {
         next = operations->next;
-        free(operations->mcc_mnc);
+        free(operations->plmn);
         free(operations->gid1);
         free(operations->gid2);
         operations = next;

--- a/euicc/es10b.c
+++ b/euicc/es10b.c
@@ -1363,8 +1363,34 @@ int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList)
     goto exit;
 err:
     fret = -1;
+    es10b_get_rat_list_free_all(*ratList);
 exit:
     free(respbuf);
     respbuf = NULL;
     return fret;
+}
+
+void es10b_get_rat_list_free_all(struct es10b_rat *ratList) {
+    struct es10b_rat *next;
+    while (ratList)
+    {
+        next = ratList->next;
+        free(ratList->pprIds);
+        es10b_operation_id_free_all(ratList->allowedOperators);
+        free(ratList->pprFlags);
+        free(ratList);
+        ratList = next;
+    }
+}
+
+void es10b_operation_id_free_all(const struct es10b_operation_id *operations) {
+    struct es10b_operation_id *next;
+    while (operations)
+    {
+        next = operations->next;
+        free(operations->mcc_mnc);
+        free(operations->gid1);
+        free(operations->gid2);
+        operations = next;
+    }
 }

--- a/euicc/es10b.c
+++ b/euicc/es10b.c
@@ -1207,3 +1207,164 @@ void es10b_pending_notification_free(struct es10b_pending_notification *PendingN
     free(PendingNotification->b64_PendingNotification);
     memset(PendingNotification, 0, sizeof(struct es10b_pending_notification));
 }
+
+int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList)
+{
+    int fret;
+    struct euicc_derutil_node n_request = {
+        .tag = 0xBF43, // GetRatRequest
+    };
+    uint32_t reqlen;
+    uint8_t *respbuf = NULL;
+    unsigned resplen;
+
+    struct es10b_rat *rat;
+    struct euicc_derutil_node tmpnode, tmpchildnode, n_profile;
+
+    *ratList = NULL;
+
+    reqlen = sizeof(ctx->apdu._internal.request_buffer.body);
+    if (euicc_derutil_pack(ctx->apdu._internal.request_buffer.body, &reqlen, &n_request))
+    {
+        goto err;
+    }
+
+    if (es10x_command(ctx, &respbuf, &resplen, ctx->apdu._internal.request_buffer.body, reqlen) < 0)
+    {
+        goto err;
+    }
+
+    if (resplen == 0)
+    {
+        goto err;
+    }
+
+    // GetRatResponse
+    if (euicc_derutil_unpack_find_tag(&tmpnode, 0xBF43, respbuf, resplen) < 0)
+    {
+        goto err;
+    }
+
+    // RulesAuthorisationTable
+    if (euicc_derutil_unpack_find_tag(&tmpnode, 0xA0, tmpnode.value, tmpnode.length) < 0)
+    {
+        goto err;
+    }
+
+    n_profile.self.ptr = tmpnode.value;
+    n_profile.self.length = 0;
+
+    // ProfilePolicyAuthorisationRule
+    while (euicc_derutil_unpack_next(&n_profile, &n_profile, tmpnode.value,tmpnode.length) == 0)
+    {
+        tmpchildnode.self.ptr = n_profile.value;
+        tmpchildnode.self.length = 0;
+
+        rat = malloc(sizeof(struct es10b_rat));
+        if (!rat)
+        {
+            goto err;
+        }
+
+        memset(rat, 0, sizeof(*rat));
+
+        while (euicc_derutil_unpack_next(&tmpchildnode, &tmpchildnode, n_profile.value,n_profile.length) == 0)
+        {
+            switch (tmpchildnode.tag) {
+                case 0x80: // ppr ids
+                    {
+                        static const char *desc[] = {"pprUpdateControl", "ppr1", "ppr2", "ppr3"};
+
+                        if (euicc_derutil_convert_bin2bits_str(&rat->pprIds, tmpchildnode.value, tmpchildnode.length, desc))
+                        {
+                            goto err;
+                        }
+                    }
+                    break;
+                case 0xA1: // allowed operators
+                    {
+                        struct euicc_derutil_node n_allowed_operator, n_operator;
+                        struct es10b_operation_id *operations_wptr;
+                        struct es10b_operation_id *p;
+
+                        n_allowed_operator.self.ptr = tmpchildnode.value;
+                        n_allowed_operator.self.length = 0;
+
+                        while (euicc_derutil_unpack_next(&n_allowed_operator, &n_allowed_operator, tmpchildnode.value,tmpchildnode.length) == 0) {
+                            p = malloc(sizeof(struct es10b_operation_id));
+                            if (!p) {
+                                goto err;
+                            }
+                            memset(p, 0, sizeof(*p));
+
+                            n_operator.self.ptr = n_allowed_operator.value;
+                            n_operator.self.length = 0;
+
+                            while (euicc_derutil_unpack_next(&n_operator, &n_operator, n_allowed_operator.value, n_allowed_operator.length) == 0)
+                            {
+                                if (n_operator.length == 0)
+                                {
+                                    continue;
+                                }
+                                switch (n_operator.tag)
+                                {
+                                    case 0x80: // mcc_mnc
+                                        p->mcc_mnc = malloc((n_operator.length * 2) + 1);
+                                        euicc_hexutil_bin2hex(p->mcc_mnc, sizeof(p->mcc_mnc), n_operator.value, n_operator.length);
+                                        break;
+                                    case 0x81: // gid1
+                                        p->gid1 = malloc((n_operator.length * 2) + 1);
+                                        euicc_hexutil_bin2hex(p->gid1, sizeof(p->gid1), n_operator.value, n_operator.length);
+                                        break;
+                                    case 0x82: // gid2
+                                        p->gid2 = malloc((n_operator.length * 2) + 1);
+                                        euicc_hexutil_bin2hex(p->gid2, sizeof(p->gid2), n_operator.value, n_operator.length);
+                                        break;
+                                }
+                            }
+                            if (operations_wptr == NULL)
+                            {
+                                operations_wptr = p;
+                            }
+                            else
+                            {
+                                operations_wptr->next = p;
+                            }
+                        }
+
+                        rat->allowedOperators = operations_wptr;
+                    }
+                    break;
+                case 0x82: // ppr flags
+                    {
+                        static const char *desc[] = {"consentRequired"};
+
+                        if (euicc_derutil_convert_bin2bits_str(&rat->pprFlags, tmpchildnode.value, tmpchildnode.length, desc))
+                        {
+                            goto err;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        if (*ratList == NULL)
+        {
+            *ratList = rat;
+        }
+        else
+        {
+            (*ratList)->next = rat;
+        }
+    }
+
+
+    fret = 0;
+    goto exit;
+err:
+    fret = -1;
+exit:
+    free(respbuf);
+    respbuf = NULL;
+    return fret;
+}

--- a/euicc/es10b.h
+++ b/euicc/es10b.h
@@ -121,7 +121,7 @@ struct es10b_rat
 
 struct es10b_operation_id
 {
-    char* mcc_mnc;
+    char* plmn;
     char* gid1;
     char* gid2;
 

--- a/euicc/es10b.h
+++ b/euicc/es10b.h
@@ -110,6 +110,24 @@ struct es10b_cancel_session_param
     uint8_t transactionIdLen;
 };
 
+struct es10b_rat
+{
+    const char** pprIds;
+    const struct es10b_operation_id* allowedOperators;
+    const char** pprFlags;
+
+    struct es10b_rat *next;
+};
+
+struct es10b_operation_id
+{
+    char* mcc_mnc;
+    char* gid1;
+    char* gid2;
+
+    struct es10b_operation_id *next;
+};
+
 int es10b_prepare_download_r(struct euicc_ctx *ctx, char **b64_PrepareDownloadResponse, struct es10b_prepare_download_param *param, struct es10b_prepare_download_param_user *param_user);
 int es10b_load_bound_profile_package_r(struct euicc_ctx *ctx, struct es10b_load_bound_profile_package_result *result, const char *b64_BoundProfilePackage);
 int es10b_get_euicc_challenge_r(struct euicc_ctx *ctx, char **b64_euiccChallenge);
@@ -129,6 +147,8 @@ int es10b_cancel_session(struct euicc_ctx *ctx);
 int es10b_list_notification(struct euicc_ctx *ctx, struct es10b_notification_metadata_list **notificationMetadataList);
 int es10b_retrieve_notifications_list(struct euicc_ctx *ctx, struct es10b_pending_notification *PendingNotification, unsigned long seqNumber);
 int es10b_remove_notification_from_list(struct euicc_ctx *ctx, unsigned long seqNumber);
+
+int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList);
 
 void es10b_notification_metadata_list_free_all(struct es10b_notification_metadata_list *notificationMetadataList);
 void es10b_pending_notification_free(struct es10b_pending_notification *PendingNotification);

--- a/euicc/es10b.h
+++ b/euicc/es10b.h
@@ -148,7 +148,9 @@ int es10b_list_notification(struct euicc_ctx *ctx, struct es10b_notification_met
 int es10b_retrieve_notifications_list(struct euicc_ctx *ctx, struct es10b_pending_notification *PendingNotification, unsigned long seqNumber);
 int es10b_remove_notification_from_list(struct euicc_ctx *ctx, unsigned long seqNumber);
 
-int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList);
-
 void es10b_notification_metadata_list_free_all(struct es10b_notification_metadata_list *notificationMetadataList);
 void es10b_pending_notification_free(struct es10b_pending_notification *PendingNotification);
+
+int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList);
+void es10b_get_rat_list_free_all(struct es10b_rat *ratList);
+void es10b_operation_id_free_all(const struct es10b_operation_id *operations);

--- a/src/applet/chip/info.c
+++ b/src/applet/chip/info.c
@@ -71,7 +71,7 @@ static int applet_main(int argc, char **argv)
                 while (rptr)
                 {
                     cJSON *joperator = cJSON_CreateObject();
-                    cJSON_AddStringOrNullToObject(joperator, "mccMnc", rptr->mcc_mnc);
+                    cJSON_AddStringOrNullToObject(joperator, "plmn", rptr->plmn);
                     cJSON_AddStringOrNullToObject(joperator, "gid1", rptr->gid1);
                     cJSON_AddStringOrNullToObject(joperator, "gid2", rptr->gid2);
                     cJSON_AddItemToArray(jAllowedOperators, joperator);

--- a/src/applet/chip/info.c
+++ b/src/applet/chip/info.c
@@ -14,10 +14,9 @@ static int applet_main(int argc, char **argv)
 {
     char *eid = NULL;
     struct es10a_euicc_configured_addresses addresses;
+    struct es10b_rat *ratList;
     struct es10c_ex_euiccinfo2 euiccinfo2;
-    cJSON *jaddresses = NULL;
-    cJSON *jeuiccinfo2 = NULL;
-    cJSON *jdata = NULL;
+    cJSON *jaddresses = NULL, *jratList = NULL, *jeuiccinfo2 = NULL, *jdata = NULL;
 
     if (es10c_get_eid(&euicc_ctx, &eid))
     {
@@ -28,6 +27,11 @@ static int applet_main(int argc, char **argv)
     if (es10a_get_euicc_configured_addresses(&euicc_ctx, &addresses) == 0)
     {
         jaddresses = cJSON_CreateObject();
+    }
+
+    if (es10b_get_rat(&euicc_ctx, &ratList) == 0)
+    {
+        jratList = cJSON_CreateArray();
     }
 
     if (es10c_ex_get_euiccinfo2(&euicc_ctx, &euiccinfo2) == 0)
@@ -46,6 +50,49 @@ static int applet_main(int argc, char **argv)
     }
     cJSON_AddItemToObject(jdata, "EuiccConfiguredAddresses", jaddresses);
     es10a_euicc_configured_addresses_free(&addresses);
+
+    if (jratList)
+    {
+        while (ratList) {
+            struct cJSON *jrat = cJSON_CreateObject();
+            if (ratList->pprIds)
+            {
+                cJSON *jPPR = cJSON_CreateArray();
+                for (int i = 0; ratList->pprIds[i] != NULL; i++)
+                {
+                    cJSON_AddItemToArray(jPPR, cJSON_CreateString(ratList->pprIds[i]));
+                }
+                cJSON_AddItemToObject(jrat, "pprIds", jPPR);
+            }
+            if (ratList->allowedOperators)
+            {
+                cJSON *jAllowedOperators = cJSON_CreateArray();
+                const struct es10b_operation_id *rptr = ratList->allowedOperators;
+                while (rptr)
+                {
+                    cJSON *joperator = cJSON_CreateObject();
+                    cJSON_AddStringOrNullToObject(joperator, "mccMnc", rptr->mcc_mnc);
+                    cJSON_AddStringOrNullToObject(joperator, "gid1", rptr->gid1);
+                    cJSON_AddStringOrNullToObject(joperator, "gid2", rptr->gid2);
+                    cJSON_AddItemToArray(jAllowedOperators, joperator);
+                    rptr = rptr->next;
+                }
+                cJSON_AddItemToObject(jrat, "allowedOperators", jAllowedOperators);
+            }
+            if (ratList->pprFlags)
+            {
+                cJSON *jFlags = cJSON_CreateArray();
+                for (int i = 0; ratList->pprFlags[i] != NULL; i++)
+                {
+                    cJSON_AddItemToArray(jFlags, cJSON_CreateString(ratList->pprFlags[i]));
+                }
+                cJSON_AddItemToObject(jrat, "pprFlags", jFlags);
+            }
+            cJSON_AddItemToArray(jratList, jrat);
+            ratList = ratList->next;
+        }
+        cJSON_AddItemToObject(jdata, "rulesAuthorisationTable", jratList);
+    }
 
     if (jeuiccinfo2)
     {


### PR DESCRIPTION
## 5.7.22 Function (ES10b): GetRAT

Related Procedures: Profile Download and Installation

Function Provider entity: ISD-R (LPA Services)

Description: This function retrieves the Rules Authorisation Table (RAT) from the eUICC. It can be called at any time. The RAT is used by the LPA to determine if a Profile containing PPRs can be installed, conditionally with End User Consent, on the eUICC as defined in section [2.9.2.4](https://www.gsma.com/esim/wp-content/uploads/2020/06/SGP.22-v2.2.2.pdf#page=46).

### Command data

The command data SHALL be coded as follows:

```asn1
GetRatRequest ::= [67] SEQUENCE { -- Tag 'BF43'
  -- No input data
}
```

### Response data

```asn1
GetRatResponse ::= [67] SEQUENCE { -- Tag 'BF43'
  rat RulesAuthorisationTable
}

RulesAuthorisationTable ::= SEQUENCE OF ProfilePolicyAuthorisationRule

ProfilePolicyAuthorisationRule ::= SEQUENCE {
  pprIds           PprIds,
  allowedOperators SEQUENCE OF OperatorId,
  pprFlags         BIT STRING {consentRequired(0)}
}

PprIds ::= BIT STRING {-- Definition of Profile Policy Rules identifiers
  pprUpdateControl(0), -- defines how to update PPRs via ES6
  ppr1(1), -- Indicator for PPR1 'Disabling of this Profile is not allowed'
  ppr2(2)  -- Indicator for PPR2  'Deletion of this Profile is not allowed'
}

OperatorId ::= SEQUENCE {
  mccMnc OCTET STRING (SIZE(3)), -- MCC&MNC coded as 3GPP TS 24.008
  gid1   OCTET STRING OPTIONAL,  -- referring to content of EF GID1 (file identifier '6F3E') in 3GPP TS 31.102 [54]
  gid2   OCTET STRING OPTIONAL   -- referring to content of EF GID2 (file identifier '6F3F') in 3GPP TS 31.102 [54]
}
```

The response data SHALL be coded as follows:

The list of `ProfilePolicyAuthorisationRule` data objects SHALL be returned in the same order as stored in the eUICC. This list MAY be empty.

The pprIds data object SHALL identify at least one PPR. The LPA SHALL ignore the `pprUpdateControl` bit.

The `allowedOperators` data object SHALL follow the description given in section [2.9.2.1](https://www.gsma.com/esim/wp-content/uploads/2020/06/SGP.22-v2.2.2.pdf#page=43).

The `consentRequired` bit set to 1 indicates that the End User consent is required.

## References

see https://www.gsma.com/esim/wp-content/uploads/2020/06/SGP.22-v2.2.2.pdf#page=206