### PR TITLE
fix: use CMAKE_INSTALL_FULL_* to get absolute path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 if(UNIX)
     include(GNUInstallDirs)
     if(NOT CMAKE_INSTALL_RPATH)
-        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}/lpac")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}/lpac")
     endif()
 endif()
 


### PR DESCRIPTION
Otherwise, we will get the wrong RPATH `lib/lpac`.