### PR TITLE
profile: fix error message for delete function

### DIFF
--- a/src/applet/profile/delete.c
+++ b/src/applet/profile/delete.c
@@ -43,7 +43,7 @@ static int applet_main(int argc, char **argv)
             reason = "unknown";
             break;
         }
-        jprint_error("es10c_disable_profile", reason);
+        jprint_error("es10c_delete_profile", reason);
         return -1;
     }
 


### PR DESCRIPTION
This was incorrectly identified as the disable function.