### PR TITLE
feat(ios-framework): add ios framework build support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,13 @@ jobs:
         include:
           - os: macos-latest
             build: {variant: make, name: macOS, artifact: macos-universal}
+          - os: macos-latest
+            build: {variant: ios-framework, name: iOS Framework, artifact: ios-framework}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+            submodules: recursive
       - name: Setup Toolchain
         run: ./scripts/setup-debian.sh
         if: runner.os == 'Linux'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmake/ios"]
+	path = cmake/ios
+	url = https://github.com/leetal/ios-cmake.git

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required (VERSION 3.8)
+
+project(euicc
+        HOMEPAGE_URL "https://github.com/estkme-group/lpac"
+        DESCRIPTION "libeuicc - eUICC Profile Manager Library"
+        LANGUAGES C CXX)
+
+set(FRAMEWORK_NAME "euicc")
+
+enable_language(C)
+enable_language(CXX)
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/../cjson ${CMAKE_BINARY_DIR}/cjson)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/../euicc LIB_EUICC_SRCS)
+
+set(CMAKE_SYSTEM_NAME iOS)
+set(CMAKE_OSX_SYSROOT "iphoneos")
+set(CMAKE_OSX_ARCHITECTURES "x86_64" "arm64")
+set(CMAKE_XCODE_ATTRIBUTE_SDKROOT "iphoneos")
+set(CMAKE_XCODE_ATTRIBUTE_ARCHS "x86_64" "arm64")
+
+add_library(${FRAMEWORK_NAME} SHARED ${LIB_EUICC_SRCS})
+
+target_link_libraries(${FRAMEWORK_NAME} cjson-static)
+target_include_directories(${FRAMEWORK_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+
+# Install headers
+file(GLOB ALL_HEADERS "../euicc/*.h")
+
+foreach(header ${ALL_HEADERS})
+    if(${header} MATCHES "^.*\.private\.h$")
+        list(REMOVE_ITEM ALL_HEADERS ${header})
+    endif()
+endforeach()
+
+# Configure libeuicc iOS frmework
+set(BUNDLE_RESOURCES
+        ../euicc/LICENSE
+        libeuicc.pc)
+
+target_sources(${FRAMEWORK_NAME} PRIVATE "${ALL_HEADERS}")
+target_sources(${FRAMEWORK_NAME} PRIVATE "${BUNDLE_RESOURCES}")
+
+set_target_properties(${FRAMEWORK_NAME} PROPERTIES
+        FRAMEWORK TRUE
+        FRAMEWORK_VERSION A
+        MACOSX_FRAMEWORK_IDENTIFIER me.estk.libeuicc
+        RESOURCE "${BUNDLE_RESOURCES}"
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        PUBLIC_HEADER "${ALL_HEADERS}"
+        RESOURCE "${BUNDLE_RESOURCES}"
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
+
+# Install a pkg-config file
+configure_file(../euicc/libeuicc.pc.in libeuicc.pc @ONLY)
+
+set_target_properties(${FRAMEWORK_NAME} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Frameworks
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Frameworks
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/Frameworks)
+
+install(TARGETS ${FRAMEWORK_NAME}
+        FRAMEWORK DESTINATION Frameworks)

--- a/framework/LICENSE
+++ b/framework/LICENSE
@@ -1,0 +1,1 @@
+../euicc/LICENSE

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -98,8 +98,14 @@ woa-zig)
     cp "$WORKSPACE/dlfcn-win32/LICENSE" output/dlfcn-win32-LICENSE
     zip -r -j "$WORKSPACE/lpac-windows-arm64-zig.zip" output/*
     ;;
+ios-framework)
+    cmake "$WORKSPACE/framework" -B . -G Xcode -DCMAKE_TOOLCHAIN_FILE=../cmake/ios/ios.toolchain.cmake -DPLATFORM=OS64COMBINED
+    cmake --build . --config Debug
+    cmake --build . --config Release
+    zip -r "$WORKSPACE/lpac-libeuicc-ios-framework.zip" Frameworks
+    ;;
 *)
-    echo "Usage: $0 {make,debian,mingw,woa-mingw,woa-zig}"
+    echo "Usage: $0 {make,debian,mingw,woa-mingw,woa-zig,ios-framework}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
1. Add a CMake build script for iOS dynamic link libraries (Frameworks)

    1. Use `./scripts/build.sh ios-framework`
    2. Follow these steps:
        1. `cd framework`
        2. `cmake -B build -G Xcode -DCMAKE_TOOLCHAIN_FILE=../cmake/ios/ios.toolchain.cmake -DPLATFORM=OS64COMBINED .`
        3. `cmake --build build --config Debug` 

4. Modify GitHub CI to add the iOS Frameworks build process