### PR TITLE
Grow buffer for retreiving AT modem replies.

### DIFF
--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -14,7 +14,7 @@ static int logic_channel = 0;
 
 static int at_expect(char **response, const char *expected)
 {
-    char buffer[1024];
+    char buffer[10240];
 
     if (response)
         *response = NULL;


### PR DESCRIPTION
The replies to some commands (eg profile list) can exceed 1k - in which case the parser fails to see the line ending and no response is returned.

(tested on Quectel RM520 module)