### PR TITLE
Working AT driver for MC7455 and EM7590, not tested with anything else

### DIFF
--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -12,7 +12,7 @@
 #define AT_BUFFER_SIZE 20480
 static FILE *fuart;
 
-static long logic_channel = 0;
+static uint64_t logic_channel = 0;
 static char *buffer;
 
 static int at_expect(char **response, const char *expected)

--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -162,7 +162,7 @@ exit:
     return fret;
 }
 
-static long apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
+static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len)
 {
     char *response;
 


### PR DESCRIPTION
Seems like with sierra wireless there are 3 issues with the existing AT code:
1. They work with logic channels that aren't integers, they use a big hex number
```
AT_DEBUG: AT+CCHO="A0000005591010FFFFFFFF8900000100"
AT_DEBUG: +CCHO: 00000000038aa32f

```
2. The code assumes that the number returned from CCHO is the logic channel number for the eUICC and should be added to the CLA base (0x80) which results in cases sending 0x8F which seems to work with *some* eUICC.
see: https://github.com/estkme-group/lpac/issues/138 for explanation
3. The code checks for AT+CGLA=? running OK as a way to detect if AT+CGLA= is supported but it doesn't mean that. in EM7590 AT+CGLA= is supported and AT+CGLA=? isn't

The following code was only tested with MC7455 and EM7590. tested with esim.me sim and sysmocom (https://shop.sysmocom.de/sysmoEUICC1-eUICC-for-consumer-eSIM-RSP/sysmoEUICC1-C2G)