### PR TITLE
fix: ensure "no conversion" result is checked correctly 

### DIFF
--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -126,8 +126,12 @@ run:
             unsigned long seqNumber;
 
             errno = 0;
-            seqNumber = strtoul(argv[i], NULL, 10);
-            if (errno != 0)
+            char *str_end;
+            seqNumber = strtoul(argv[i], &str_end, 10);
+            // Although POSIX said user should check errno instead of return value,
+            // but errno may not be set when no conversion is performed according to C99.
+            // Check nptr is same as str_end to ensure there is no conversion.
+            if ((seqNumber == 0 && strcmp(argv[i], str_end)) || errno != 0)
             {
                 continue;
             }

--- a/src/applet/notification/remove.c
+++ b/src/applet/notification/remove.c
@@ -96,8 +96,12 @@ run:
             unsigned long seqNumber;
 
             errno = 0;
-            seqNumber = strtoul(argv[i], NULL, 10);
-            if (errno != 0)
+            char *str_end;
+            seqNumber = strtoul(argv[i], &str_end, 10);
+            // Although POSIX said user should check errno instead of return value,
+            // but errno may not be set when no conversion is performed according to C99.
+            // Check nptr is same as str_end to ensure there is no conversion.
+            if ((seqNumber == 0 && strcmp(argv[i], str_end)) || errno != 0)
             {
                 continue;
             }


### PR DESCRIPTION
Although POSIX said user should check errno instead of return value,
but errno may not be set when no conversion is performed according to C99.
Check nptr is same as str_end to ensure there is no conversion.

Signed-off-by: Celeste Liu <CoelacanthusHex@gmail.com>