### PR TITLE
refactor: optimize getopt() usage

### DIFF
--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -67,10 +67,9 @@ static int applet_main(int argc, char **argv)
     int fret = 0;
     int all = 0;
     int autoremove = 0;
-    int argc_seq_offset = 1;
+    int opt = 0;
 
-    int opt = getopt(argc, argv, opt_string);
-    for (int i = 0; opt != -1; i++)
+    while ((opt = getopt(argc, argv, opt_string)) != -1)
     {
         switch (opt)
         {
@@ -87,14 +86,10 @@ static int applet_main(int argc, char **argv)
             printf("\t -r Automatically remove processed notifications\r\n");
             return -1;
         default:
-            goto run;
             break;
         }
-        argc_seq_offset++;
-        opt = getopt(argc, argv, opt_string);
     }
 
-run:
     if (all)
     {
         struct es10b_notification_metadata_list *notifications, *rptr;
@@ -121,7 +116,7 @@ run:
     }
     else
     {
-        for (int i = argc_seq_offset; i < argc; i++)
+        for (int i = optind; i < argc; i++)
         {
             unsigned long seqNumber;
 

--- a/src/applet/notification/remove.c
+++ b/src/applet/notification/remove.c
@@ -41,10 +41,9 @@ static int applet_main(int argc, char **argv)
 
     int fret = 0;
     int all = 0;
-    int argc_seq_offset = 1;
+    int opt = 0;
 
-    int opt = getopt(argc, argv, opt_string);
-    for (int i = 0; opt != -1; i++)
+    while ((opt = getopt(argc, argv, opt_string)) != -1)
     {
         switch (opt)
         {
@@ -57,14 +56,10 @@ static int applet_main(int argc, char **argv)
             printf("\t -a All notifications\r\n");
             return -1;
         default:
-            goto run;
             break;
         }
-        argc_seq_offset++;
-        opt = getopt(argc, argv, opt_string);
     }
 
-run:
     if (all)
     {
         struct es10b_notification_metadata_list *notifications, *rptr;
@@ -91,7 +86,7 @@ run:
     }
     else
     {
-        for (int i = argc_seq_offset; i < argc; i++)
+        for (int i = optind; i < argc; i++)
         {
             unsigned long seqNumber;
 

--- a/src/applet/profile/discovery.c
+++ b/src/applet/profile/discovery.c
@@ -24,8 +24,7 @@ static int applet_main(int argc, char **argv)
 
     cJSON *jdata = NULL;
 
-    opt = getopt(argc, argv, opt_string);
-    while (opt != -1)
+    while ((opt = getopt(argc, argv, opt_string)) != -1)
     {
         switch (opt)
         {

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -49,8 +49,7 @@ static int applet_main(int argc, char **argv)
     cJSON *jmetadata = NULL;
     struct es8p_metadata *profile_metadata = NULL;
 
-    opt = getopt(argc, argv, opt_string);
-    while (opt != -1)
+    while ((opt = getopt(argc, argv, opt_string)) != -1)
     {
         switch (opt)
         {
@@ -90,7 +89,6 @@ static int applet_main(int argc, char **argv)
         default:
             break;
         }
-        opt = getopt(argc, argv, opt_string);
     }
 
     if (activation_code != NULL)


### PR DESCRIPTION
* optind will be the index of the first mismatched argument, so use it directly.
* use while instead of for