### PR TITLE
Expose es10x max segment size as an option in euicc_ctx

### DIFF
--- a/euicc/euicc.c
+++ b/euicc/euicc.c
@@ -99,9 +99,9 @@ int es10x_command_iter(struct euicc_ctx *ctx, const uint8_t *der_req, unsigned r
     while (req_len)
     {
         uint8_t rlen;
-        if (req_len > 120)
+        if (req_len > ctx->es10x_mss)
         {
-            rlen = 120;
+            rlen = ctx->es10x_mss;
             ret = es10x_command_buildrequest_continue(ctx, reqseq, &req, req_ptr, rlen);
         }
         else
@@ -177,6 +177,8 @@ int euicc_init(struct euicc_ctx *ctx)
         ctx->aid = (const uint8_t *)ISD_R_AID;
         ctx->aid_len = sizeof(ISD_R_AID) - 1;
     }
+
+    ctx->es10x_mss = 120;
 
     ret = ctx->apdu.interface->connect(ctx);
     if (ret < 0)

--- a/euicc/euicc.h
+++ b/euicc/euicc.h
@@ -8,6 +8,7 @@ struct euicc_ctx
 {
     const uint8_t *aid;
     uint8_t aid_len;
+    uint8_t es10x_mss;
     struct
     {
         const struct euicc_apdu_interface *interface;


### PR DESCRIPTION
This is useful on mobile devices where larger MTU + faster baud rate can result in 0x6601 checksum errors. This is going to be used in OpenEUICC (lpac-jni) to set the mss lower for removable eUICCs.