### PR TITLE
chore: enable LTO by default and add w/o LTO CI for debug

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,9 @@ jobs:
           - {variant: woa-mingw, name: Windows on ARM with MinGW, artifact: windows-arm64}
         include:
           - os: macos-latest
-            build:
-              - {variant: make, name: macOS, artifact: macos-universal}
-              - {variant: make-without-lto, name: macOS (w/o LTO), artifact: macos-universal-without-lto}
+            build: {variant: make, name: macOS, artifact: macos-universal}
+          - os: macos-latest
+            build: {variant: make-without-lto, name: macOS (w/o LTO), artifact: macos-universal-without-lto}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,12 +18,15 @@ jobs:
         os: [ubuntu-latest]
         build:
           - {variant: make, name: Linux, artifact: linux-x64}
+          - {variant: make-without-lto, name: Linux (w/o LTO), artifact: linux-x64-without-lto}
           - {variant: debian, name: Debian, artifact: debian-x64}
           - {variant: mingw, name: Windows with MinGW, artifact: windows-x64}
           - {variant: woa-mingw, name: Windows on ARM with MinGW, artifact: windows-arm64}
         include:
           - os: macos-latest
-            build: {variant: make, name: macOS, artifact: macos-universal}
+            build:
+              - {variant: make, name: macOS, artifact: macos-universal}
+              - {variant: make-without-lto, name: macOS (w/o LTO), artifact: macos-universal-without-lto}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,18 @@ list(APPEND CMAKE_MODULE_PATH ${LPAC_CMAKE_MODULE_PATH})
 
 # add_compile_options(-Wall -Wextra -Wpedantic)
 
+# Enable LTO when possible.
+cmake_policy(SET CMP0069 NEW)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT result OUTPUT output)
+if(result)
+    if(NOT DEFINED CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
+else()
+    message(INFO "IPO is not supported: ${output}")
+endif()
+
 if (APPLE)
     set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64")
 endif()

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -21,6 +21,13 @@ make)
     copy-usage "$BUILD/output"
     create-bundle "$ARTIFACT/lpac-$KERNEL-$MATCHINE.zip" "$BUILD/output"
     ;;
+make-without-lto)
+    cmake -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF "$WORKSPACE"
+    make -j
+    copy-license "$BUILD/output"
+    copy-usage "$BUILD/output"
+    create-bundle "$ARTIFACT/lpac-$KERNEL-$MATCHINE-without-lto.zip" "$BUILD/output"
+    ;;
 debian)
     cmake "$WORKSPACE" -DCPACK_GENERATOR=DEB
     make -j package


### PR DESCRIPTION
* Better performance, small size, in theory.
* Cover more test points.