### PR TITLE
Fix AT driver

### DIFF
--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -55,7 +55,7 @@ static int apdu_interface_connect(struct euicc_ctx *ctx)
         device = "/dev/ttyUSB0";
     }
 
-    fuart = fopen(device, "r+");
+    fuart = fopen(device, "rb+");
     if (fuart == NULL)
     {
         fprintf(stderr, "Failed to open device: %s\n", device);


### PR DESCRIPTION
The AT driver was very unreliable, sending only partial commands on Quectel devices. This patch seems to fix it for the most part.