### PR TITLE
Update USAGE.md

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -163,7 +163,7 @@ There is no secondary confirmation for deleting a Profile, so please perform it 
 - `-m`: Matching ID, activation code. optional.
 - `-c`: Confirmation Code, optional.
 - `-i`: The IMEI of the device to which Profile is to be downloaded, optional.
-- `-a`: LPA qrcode activation code string, e.g: `LPA:1$<sm-dp+ domain>$<matching id>`, if provided this option takes precedence over the `-s` and `-m` options, optional.
+- `-a`: LPA qrcode activation code string, e.g: `LPA:1$<sm-dp+ domain>$<matching id>`, if provided this option takes precedence over the `-s` and `-m` options, optional. Depending on your shell, you may need to enclose this string in single quotes, to prevent your shell from treating $ as a variable.
 - `-p`: Interactive preview mode, optional.
 
 <details>


### PR DESCRIPTION
Indicate the need to use single quotes when using the `-a` switch for `lpac profile download`, to prevent the shell treating the $ in the activation code string as a variable.