### PR TITLE
feat: human readable error code (pcsclite only)

### DIFF
--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -29,7 +29,7 @@ static SCARDCONTEXT pcsc_ctx;
 static SCARDHANDLE pcsc_hCard;
 static LPSTR pcsc_mszReaders;
 
-static void pcsc_error_text(const char *method, const int32_t code) {
+static void pcsc_error(const char *method, const int32_t code) {
 #ifdef __MINGW32__
     fprintf(stderr, "%s failed: %08X\n", method, code);
 #else
@@ -49,7 +49,7 @@ static int pcsc_ctx_open(void)
     ret = SCardEstablishContext(SCARD_SCOPE_SYSTEM, NULL, NULL, &pcsc_ctx);
     if (ret != SCARD_S_SUCCESS)
     {
-        pcsc_error_text("SCardEstablishContext()", ret);
+        pcsc_error("SCardEstablishContext()", ret);
         return -1;
     }
 
@@ -62,7 +62,7 @@ static int pcsc_ctx_open(void)
     ret = SCardListReaders(pcsc_ctx, NULL, NULL, &dwReaders);
     if (ret != SCARD_S_SUCCESS)
     {
-        pcsc_error_text("SCardListReaders()", ret);
+        pcsc_error("SCardListReaders()", ret);
         return -1;
     }
     pcsc_mszReaders = malloc(sizeof(char) * dwReaders);
@@ -75,7 +75,7 @@ static int pcsc_ctx_open(void)
 #endif
     if (ret != SCARD_S_SUCCESS)
     {
-        pcsc_error_text("SCardListReaders()", ret);
+        pcsc_error("SCardListReaders()", ret);
         return -1;
     }
 
@@ -129,7 +129,7 @@ static int pcsc_open_hCard_iter(int index, const char *reader, void *userdata)
     ret = SCardConnect(pcsc_ctx, reader, SCARD_SHARE_EXCLUSIVE, SCARD_PROTOCOL_T0, &pcsc_hCard, &dwActiveProtocol);
     if (ret != SCARD_S_SUCCESS)
     {
-        pcsc_error_text("SCardConnect()", ret);
+        pcsc_error("SCardConnect()", ret);
         return -1;
     }
 
@@ -176,7 +176,7 @@ static int pcsc_transmit_lowlevel(uint8_t *rx, uint32_t *rx_len, const uint8_t *
     ret = SCardTransmit(pcsc_hCard, SCARD_PCI_T0, tx, tx_len, NULL, rx, &rx_len_merged);
     if (ret != SCARD_S_SUCCESS)
     {
-        pcsc_error_text("SCardTransmit()", ret);
+        pcsc_error("SCardTransmit()", ret);
         return -1;
     }
 

--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -31,9 +31,9 @@ static LPSTR pcsc_mszReaders;
 
 static void pcsc_error_text(const char *method, const int32_t code) {
 #ifdef __MINGW32__
-    fprintf(stderr, "%s failed: %08X", method, code);
+    fprintf(stderr, "%s failed: %08X\n", method, code);
 #else
-    fprintf(stderr, "%s failed: %08X (%s)", method, code, pcsc_stringify_error(code));
+    fprintf(stderr, "%s failed: %08X (%s)\n", method, code, pcsc_stringify_error(code));
 #endif
 }
 

--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -109,7 +109,7 @@ static int pcsc_iter_reader(int (*callback)(int index, const char *reader, void 
     return -1;
 }
 
-static int pcsc_open_hCard_iter(const int index, const char *reader, void *userdata)
+static int pcsc_open_hCard_iter(int index, const char *reader, void *userdata)
 {
     int ret;
     int id;
@@ -118,7 +118,7 @@ static int pcsc_open_hCard_iter(const int index, const char *reader, void *userd
     id = 0;
     if (getenv(INTERFACE_SELECT_ENV))
     {
-        id = (int) strtol(getenv(INTERFACE_SELECT_ENV), NULL, 10);
+        id = atoi(getenv(INTERFACE_SELECT_ENV));
     }
 
     if (id != index)

--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -33,7 +33,7 @@ static char *pcsc_error_text(const int32_t code) {
     char *formatted = malloc(100);
     if (!formatted) return NULL;
 #ifdef __MINGW32__
-    snprintf(buf, 8, "%08X",  code);
+    snprintf(formatted, 8, "%08X",  code);
 #else
     snprintf(formatted, 100, "%08X (%s)", code, pcsc_stringify_error(code));
 #endif

--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -109,16 +109,16 @@ static int pcsc_iter_reader(int (*callback)(int index, const char *reader, void 
     return -1;
 }
 
-static int pcsc_open_hCard_iter(int index, const char *reader, void *userdata)
+static int pcsc_open_hCard_iter(const int index, const char *reader, void *userdata)
 {
     int ret;
-    long id;
+    int id;
     DWORD dwActiveProtocol;
 
     id = 0;
     if (getenv(INTERFACE_SELECT_ENV))
     {
-        id = strtol(getenv(INTERFACE_SELECT_ENV), NULL, 10);
+        id = (int) strtol(getenv(INTERFACE_SELECT_ENV), NULL, 10);
     }
 
     if (id != index)


### PR DESCRIPTION
> For a human readable representation of an error the function pcsc_stringify_error() is declared in pcsclite.h.
>
> This function is not available on Microsoft(R) winscard API and is pcsc-lite specific.

from https://github.com/LudovicRousseau/PCSC/blob/f0f4fa1586f1cc695ad42c88d19dc4f15bfa3c71/src/winscard.c#L68-L70

## Effect

```console
$ ./output/lpac chip
SCardConnect() failed: 80100009 (Unknown reader specified.)
{"type":"lpa","payload":{"code":-1,"message":"euicc_init","data":""}}
```