### PR TITLE
feat: improve isd-r aid handling

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,6 @@
 #include <processenv.h>
 #endif
 
-#define ISD_R_AID_MIN_LENGTH 5
 #define ISD_R_AID_MAX_LENGTH 16
 
 static int driver_applet_main(int argc, char **argv)
@@ -67,15 +66,9 @@ void main_init_euicc()
     {
         uint8_t custom_aid[ISD_R_AID_MAX_LENGTH];
         const int custom_aid_len = euicc_hexutil_hex2bin(custom_aid, ISD_R_AID_MAX_LENGTH, custom_aid_str);
-        if (custom_aid_len < ISD_R_AID_MIN_LENGTH || custom_aid_len > ISD_R_AID_MAX_LENGTH)
+        if (custom_aid_len < 1)
         {
-            char message[80];
-            sprintf(
-                message,
-                "invalid custom ISD-R AID given (length must be between %d and %d bytes)",
-                ISD_R_AID_MIN_LENGTH, ISD_R_AID_MAX_LENGTH
-            );
-            jprint_error("euicc_init", message);
+            jprint_error("euicc_init", "invalid custom ISD-R AID given");
             exit(-1);
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,13 @@ void main_init_euicc()
         const int custom_aid_len = euicc_hexutil_hex2bin(custom_aid, ISD_R_AID_MAX_LENGTH, custom_aid_str);
         if (custom_aid_len < ISD_R_AID_MIN_LENGTH || custom_aid_len > ISD_R_AID_MAX_LENGTH)
         {
-            jprint_error("euicc_init", "invalid custom AID given");
+            char message[80];
+            sprintf(
+                message,
+                "invalid custom ISD-R AID given (length must be between %d and %d bytes)",
+                ISD_R_AID_MIN_LENGTH, ISD_R_AID_MAX_LENGTH
+            );
+            jprint_error("euicc_init", message);
             exit(-1);
         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,8 @@
 #include <processenv.h>
 #endif
 
-#define ISD_R_AID_STR_LENGTH 16
+#define ISD_R_AID_MIN_LENGTH 5
+#define ISD_R_AID_MAX_LENGTH 16
 
 static int driver_applet_main(int argc, char **argv)
 {
@@ -64,16 +65,17 @@ void main_init_euicc()
     const char *custom_aid_str = getenv("LPAC_CUSTOM_ISD_R_AID");
     if (custom_aid_str)
     {
-        unsigned char custom_aid[ISD_R_AID_STR_LENGTH];
-        const int custom_aid_len = euicc_hexutil_hex2bin(custom_aid, ISD_R_AID_STR_LENGTH, custom_aid_str);
-        if (custom_aid_len != ISD_R_AID_STR_LENGTH)
+        unsigned char custom_aid[ISD_R_AID_MAX_LENGTH];
+        const int custom_aid_len = euicc_hexutil_hex2bin(custom_aid, ISD_R_AID_MAX_LENGTH, custom_aid_str);
+        if (custom_aid_len < ISD_R_AID_MIN_LENGTH || custom_aid_len > ISD_R_AID_MAX_LENGTH)
         {
             jprint_error("euicc_init", "invalid custom AID given");
             exit(-1);
         }
 
-        euicc_ctx.aid = custom_aid;
         euicc_ctx.aid_len = custom_aid_len;
+        euicc_ctx.aid = malloc(custom_aid_len);
+        memcpy(euicc_ctx.aid, custom_aid, custom_aid_len);
     }
 
     if (euicc_init(&euicc_ctx))

--- a/src/main.c
+++ b/src/main.c
@@ -65,7 +65,7 @@ void main_init_euicc()
     const char *custom_aid_str = getenv("LPAC_CUSTOM_ISD_R_AID");
     if (custom_aid_str)
     {
-        unsigned char custom_aid[ISD_R_AID_MAX_LENGTH];
+        uint8_t custom_aid[ISD_R_AID_MAX_LENGTH];
         const int custom_aid_len = euicc_hexutil_hex2bin(custom_aid, ISD_R_AID_MAX_LENGTH, custom_aid_str);
         if (custom_aid_len < ISD_R_AID_MIN_LENGTH || custom_aid_len > ISD_R_AID_MAX_LENGTH)
         {
@@ -73,9 +73,8 @@ void main_init_euicc()
             exit(-1);
         }
 
+        euicc_ctx.aid = custom_aid;
         euicc_ctx.aid_len = custom_aid_len;
-        euicc_ctx.aid = malloc(custom_aid_len);
-        memcpy(euicc_ctx.aid, custom_aid, custom_aid_len);
     }
 
     if (euicc_init(&euicc_ctx))


### PR DESCRIPTION
> This class encapsulates the Application Identifier (AID) associated with an applet. An AID is defined in ISO 7816-5 to be a sequence of bytes between 5 and 16 bytes in length.

see https://docs.oracle.com/javacard/3.0.5/api/javacard/framework/AID.html

## References

- https://cdn.standards.iteh.ai/samples/19980/8ff6c7ccc9254fe4b7a8a21c0bf59424/ISO-IEC-7816-5-1994.pdf