### PR TITLE
refactor: always use \n for newline and make fuart unbuffered

### DIFF
--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -26,7 +26,7 @@ static int at_expect(char **response, const char *expected)
         fgets(buffer, AT_BUFFER_SIZE, fuart);
         buffer[strcspn(buffer, "\r\n")] = 0;
         if (getenv("AT_DEBUG"))
-            printf("AT_DEBUG: %s\r\n", buffer);
+            printf("AT_DEBUG: %s\n", buffer);
         if (strcmp(buffer, "ERROR") == 0)
         {
             return -1;

--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -61,6 +61,7 @@ static int apdu_interface_connect(struct euicc_ctx *ctx)
         fprintf(stderr, "Failed to open device: %s\n", device);
         return -1;
     }
+    setbuf(fuart, NULL);
 
     fprintf(fuart, "AT+CCHO=?\r\n");
     if (at_expect(NULL, NULL))

--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -8,7 +8,6 @@
 
 #include <euicc/interface.h>
 #include <euicc/hexutil.h>
-#include "print.h"
 
 #define AT_BUFFER_SIZE 20480
 static FILE *fuart;
@@ -216,7 +215,7 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct)
     buffer = malloc(AT_BUFFER_SIZE);
     if (!buffer)
     {
-        fprintlnf(stderr, "Failed to allocate memory");
+        fprintf(stderr, "Failed to allocate memory\n");
         return -1;
     }
 

--- a/driver/apdu/pcsc.c
+++ b/driver/apdu/pcsc.c
@@ -15,7 +15,6 @@
 
 #include <cjson/cJSON_ex.h>
 #include <euicc/interface.h>
-#include "print.h"
 
 #define INTERFACE_SELECT_ENV "DRIVER_IFID"
 
@@ -32,7 +31,7 @@ static SCARDHANDLE pcsc_hCard;
 static LPSTR pcsc_mszReaders;
 
 static void pcsc_error(const char *method, const int32_t code) {
-    fprintlnf(stderr, "%s failed: %08X (%s)", method, code, pcsc_stringify_error(code));
+    fprintf(stderr, "%s failed: %08X (%s)\n", method, code, pcsc_stringify_error(code));
 }
 
 static int pcsc_ctx_open(void)
@@ -66,7 +65,7 @@ static int pcsc_ctx_open(void)
     pcsc_mszReaders = malloc(sizeof(char) * dwReaders);
     if (pcsc_mszReaders == NULL)
     {
-        fprintlnf(stderr, "malloc: not enough memory");
+        fprintf(stderr, "malloc: not enough memory\n");
         return -1;
     }
     ret = SCardListReaders(pcsc_ctx, NULL, pcsc_mszReaders, &dwReaders);
@@ -299,7 +298,8 @@ static int json_print(cJSON *jpayload)
     }
     cJSON_Delete(jroot);
 
-    fprintlnf(stdout, "%s", jstr);
+    fprintf(stdout, "%s\n", jstr);
+    fflush(stdout);
 
     free(jstr);
     jstr = NULL;
@@ -338,7 +338,7 @@ static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t
     *rx = malloc(EUICC_INTERFACE_BUFSZ);
     if (!*rx)
     {
-        fprintlnf(stderr, "SCardTransmit() RX buffer alloc failed");
+        fprintf(stderr, "SCardTransmit() RX buffer alloc failed\n");
         return -1;
     }
     *rx_len = EUICC_INTERFACE_BUFSZ;
@@ -417,7 +417,7 @@ static int libapduinterface_main(int argc, char **argv)
 {
     if (argc < 2)
     {
-        fprintlnf(stderr, "Usage: %s <list>", argv[0]);
+        fprintf(stderr, "Usage: %s <list>\n", argv[0]);
         return -1;
     }
 

--- a/driver/apdu/stdio.c
+++ b/driver/apdu/stdio.c
@@ -9,7 +9,6 @@
 #include <cjson/cJSON_ex.h>
 #include <euicc/interface.h>
 #include <euicc/hexutil.h>
-#include "print.h"
 
 // getline is a GNU extension, Mingw32 macOS and FreeBSD don't have (a working) one
 static int afgets(char **obuf, FILE *fp)
@@ -88,7 +87,8 @@ static int json_print(cJSON *jpayload)
     }
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    fprintf(stdout, "%s\r\n", jstr);
+    fflush(stdout);
 
     free(jstr);
     jstr = NULL;

--- a/driver/apdu/stdio.c
+++ b/driver/apdu/stdio.c
@@ -43,7 +43,7 @@ static int afgets(char **obuf, FILE *fp)
         }
     }
 
-    (*obuf)[strcspn(*obuf, "\r\n")] = 0;
+    (*obuf)[strcspn(*obuf, "\n")] = 0;
 
     return 0;
 
@@ -87,7 +87,7 @@ static int json_print(cJSON *jpayload)
     }
     cJSON_Delete(jroot);
 
-    fprintf(stdout, "%s\r\n", jstr);
+    fprintf(stdout, "%s\n", jstr);
     fflush(stdout);
 
     free(jstr);

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -29,8 +29,6 @@
 #ifdef LPAC_WITH_HTTP_CURL
 #include "driver/http/curl.h"
 #endif
-#include "print.h"
-
 #include "driver/apdu/stdio.h"
 #include "driver/http/stdio.h"
 
@@ -95,26 +93,26 @@ int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name
     _driver_apdu = _find_driver(DRIVER_APDU, apdu_driver_name);
     if (_driver_apdu == NULL)
     {
-        eprintlnf("No APDU driver found");
+        fprintf(stderr, "No APDU driver found\n");
         return -1;
     }
 
     _driver_http = _find_driver(DRIVER_HTTP, http_driver_name);
     if (_driver_http == NULL)
     {
-        eprintlnf("No HTTP driver found");
+        fprintf(stderr, "No HTTP driver found\n");
         return -1;
     }
 
     if (_driver_apdu->init(&euicc_driver_interface_apdu))
     {
-        eprintlnf("APDU driver init failed");
+        fprintf(stderr, "APDU driver init failed\n");
         return -1;
     }
 
     if (_driver_http->init(&euicc_driver_interface_http))
     {
-        eprintlnf("HTTP driver init failed");
+        fprintf(stderr, "HTTP driver init failed\n");
         return -1;
     }
 

--- a/driver/http/curl.c
+++ b/driver/http/curl.c
@@ -5,7 +5,6 @@
 #include <string.h>
 
 #include <euicc/interface.h>
-#include "print.h"
 
 #ifndef _WIN32
 #include <curl/curl.h>
@@ -60,7 +59,7 @@ static size_t http_trans_write_callback(void *contents, size_t size, size_t nmem
     if (mem->data == NULL)
     {
         /* out of memory! */
-        printlnf("not enough memory (realloc returned NULL)");
+        printf("not enough memory (realloc returned NULL)\n");
         return 0;
     }
 
@@ -115,7 +114,7 @@ static int http_interface_transmit(struct euicc_ctx *ctx, const char *url, uint3
 
     if (res != CURLE_OK)
     {
-        eprintlnf("curl_easy_perform() failed: %s", libcurl._curl_easy_strerror(res));
+        fprintf(stderr, "curl_easy_perform() failed: %s\n", libcurl._curl_easy_strerror(res));
         goto err;
     }
 
@@ -141,7 +140,7 @@ static int _init_libcurl(void)
 #ifdef _WIN32
     if (!(libcurl_interface_dlhandle = dlopen("libcurl.dll", RTLD_LAZY)))
     {
-        eprintlnf("libcurl init err: %s", dlerror());
+        fprintf(stderr, "libcurl init err: %s\n", dlerror());
         return -1;
     }
 

--- a/driver/http/stdio.c
+++ b/driver/http/stdio.c
@@ -9,7 +9,6 @@
 #include <cjson/cJSON_ex.h>
 #include <euicc/interface.h>
 #include <euicc/hexutil.h>
-#include "print.h"
 
 // getline is a GNU extension, Mingw32 macOS and FreeBSD don't have (a working) one
 static int afgets(char **obuf, FILE *fp)
@@ -88,7 +87,8 @@ static int json_print(cJSON *jpayload)
     }
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    fprintf(stdout, "%s\r\n", jstr);
+    fflush(stdout);
 
     free(jstr);
     jstr = NULL;

--- a/driver/http/stdio.c
+++ b/driver/http/stdio.c
@@ -43,7 +43,7 @@ static int afgets(char **obuf, FILE *fp)
         }
     }
 
-    (*obuf)[strcspn(*obuf, "\r\n")] = 0;
+    (*obuf)[strcspn(*obuf, "\n")] = 0;
 
     return 0;
 
@@ -87,7 +87,7 @@ static int json_print(cJSON *jpayload)
     }
     cJSON_Delete(jroot);
 
-    fprintf(stdout, "%s\r\n", jstr);
+    fprintf(stdout, "%s\n", jstr);
     fflush(stdout);
 
     free(jstr);

--- a/driver/print.h
+++ b/driver/print.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#define fprintlnf(f, fmt, ...) fprintf(f, fmt "\n", ## __VA_ARGS__); fflush(f)
-#define eprintlnf(fmt, ...) fprintlnf(stderr, fmt, ## __VA_ARGS__)
-#define printlnf(fmt, ...) fprintlnf(stdout, fmt, ## __VA_ARGS__)

--- a/euicc/es10c.c
+++ b/euicc/es10c.c
@@ -8,8 +8,8 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <string.h>
-#include "print.h"
 
 int es10c_get_profiles_info(struct euicc_ctx *ctx, struct es10c_profile_info_list **profileInfoList)
 {

--- a/euicc/es9p.c
+++ b/euicc/es9p.c
@@ -6,7 +6,6 @@
 #include <string.h>
 
 #include <cjson/cJSON_ex.h>
-#include "print.h"
 
 static const char *lpa_header[] = {
     "User-Agent: gsma-rsp-lpad",
@@ -59,7 +58,7 @@ static int es9p_trans_ex(struct euicc_ctx *ctx, const char *url, const char *url
 
     if (getenv("LIBEUICC_DEBUG_HTTP"))
     {
-        fprintlnf(stderr, "[DEBUG] [HTTP] [TX] url: %s, data: %s", full_url, str_tx);
+        fprintf(stderr, "[DEBUG] [HTTP] [TX] url: %s, data: %s\n", full_url, str_tx);
     }
     if (ctx->http.interface->transmit(ctx, full_url, &rcode_mearged, &rbuf, &rlen, (const uint8_t *)str_tx, strlen(str_tx), lpa_header) < 0)
     {
@@ -67,7 +66,7 @@ static int es9p_trans_ex(struct euicc_ctx *ctx, const char *url, const char *url
     }
     if (getenv("LIBEUICC_DEBUG_HTTP"))
     {
-        fprintlnf(stderr, "[DEBUG] [HTTP] [RX] rcode: %d, data: %s", rcode_mearged, (const char *) rbuf);
+        fprintf(stderr, "[DEBUG] [HTTP] [RX] rcode: %d, data: %s\n", rcode_mearged, rbuf);
     }
 
     free(full_url);

--- a/euicc/interface.c
+++ b/euicc/interface.c
@@ -44,7 +44,6 @@ static void euicc_apdu_request_print(const struct apdu_request *req, uint32_t re
     for (uint32_t i = 0; i < (request_len - sizeof(struct apdu_request)); i++)
         fprintf(stderr, "%02X ", (req->data[i] & 0xFF));
     fprintf(stderr, "\n");
-    fflush(stderr);
 }
 
 static void euicc_apdu_response_print(const struct apdu_response *resp)
@@ -53,7 +52,6 @@ static void euicc_apdu_response_print(const struct apdu_response *resp)
     for (uint32_t i = 0; i < resp->length; i++)
         fprintf(stderr, "%02X ", (resp->data[i] & 0xFF));
     fprintf(stderr, "\n");
-    fflush(stderr);
 }
 
 int euicc_apdu_transmit(struct euicc_ctx *ctx, struct apdu_response *response, const struct apdu_request *request, uint32_t request_len)

--- a/euicc/print.h
+++ b/euicc/print.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#define fprintlnf(f, fmt, ...) fprintf(f, fmt "\n", ## __VA_ARGS__); fflush(f)
-#define eprintlnf(fmt, ...) fprintlnf(stderr, fmt, ## __VA_ARGS__)
-#define printlnf(fmt, ...) fprintlnf(stdout, fmt, ## __VA_ARGS__)

--- a/src/applet.c
+++ b/src/applet.c
@@ -1,6 +1,4 @@
 #include "applet.h"
-
-#include <jprint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -19,7 +17,7 @@ static void applet_usage(const char *selfname, const struct applet_entry **entri
         }
     }
 
-    printlnf(">");
+    printf(">\n");
 }
 
 int applet_entry(int argc, char **argv, const struct applet_entry **entries)
@@ -43,7 +41,7 @@ int applet_entry(int argc, char **argv, const struct applet_entry **entries)
         }
     }
 
-    printlnf("Unknown command: %s", argv[1]);
+    printf("Unknown command: %s\n", argv[1]);
     applet_usage(argv[0], entries);
     return -1;
 }

--- a/src/applet/chip/defaultsmdp.c
+++ b/src/applet/chip/defaultsmdp.c
@@ -13,7 +13,7 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s <smdp>", argv[0]);
+        printf("Usage: %s <smdp>\n", argv[0]);
         return -1;
     }
 

--- a/src/applet/chip/purge.c
+++ b/src/applet/chip/purge.c
@@ -13,14 +13,14 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s [yes|other]", argv[0]);
-        printlnf("\t\tConfirm purge eUICC, all data will lost!");
+        printf("Usage: %s [yes|other]\n", argv[0]);
+        printf("\t\tConfirm purge eUICC, all data will lost!\n");
         return -1;
     }
 
     if (strcmp(argv[1], "yes") != 0)
     {
-        printlnf("Purge canceled");
+        printf("Purge canceled\n");
         return -1;
     }
 

--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -81,9 +81,9 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printlnf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...", argv[0]);
-            printlnf("\t -a All notifications");
-            printlnf("\t -r Automatically remove processed notifications");
+            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\r\n", argv[0]);
+            printf("\t -a All notifications\r\n");
+            printf("\t -r Automatically remove processed notifications\r\n");
             return -1;
         default:
             break;

--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -81,9 +81,9 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\r\n", argv[0]);
-            printf("\t -a All notifications\r\n");
-            printf("\t -r Automatically remove processed notifications\r\n");
+            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\n", argv[0]);
+            printf("\t -a All notifications\n");
+            printf("\t -r Automatically remove processed notifications\n");
             return -1;
         default:
             break;

--- a/src/applet/notification/remove.c
+++ b/src/applet/notification/remove.c
@@ -52,8 +52,8 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printlnf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...", argv[0]);
-            printlnf("\t -a All notifications");
+            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\r\n", argv[0]);
+            printf("\t -a All notifications\r\n");
             return -1;
         default:
             break;

--- a/src/applet/notification/remove.c
+++ b/src/applet/notification/remove.c
@@ -52,8 +52,8 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\r\n", argv[0]);
-            printf("\t -a All notifications\r\n");
+            printf("Usage: %s [OPTIONS] [seqNumber_0] [seqNumber_1]...\n", argv[0]);
+            printf("\t -a All notifications\n");
             return -1;
         default:
             break;

--- a/src/applet/profile/delete.c
+++ b/src/applet/profile/delete.c
@@ -14,7 +14,7 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s [iccid/aid]", argv[0]);
+        printf("Usage: %s [iccid/aid]\n", argv[0]);
         return -1;
     }
 

--- a/src/applet/profile/disable.c
+++ b/src/applet/profile/disable.c
@@ -15,8 +15,8 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s [iccid/aid] [refreshflag]", argv[0]);
-        printlnf("\t[refreshflag]: optional");
+        printf("Usage: %s [iccid/aid] [refreshflag]\n", argv[0]);
+        printf("\t[refreshflag]: optional\n");
         return -1;
     }
 

--- a/src/applet/profile/discovery.c
+++ b/src/applet/profile/discovery.c
@@ -36,10 +36,10 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printf("Usage: %s [OPTIONS]\r\n", argv[0]);
-            printf("\t -s SM-DS Domain\r\n");
-            printf("\t -i IMEI\r\n");
-            printf("\t -h This help info\r\n");
+            printf("Usage: %s [OPTIONS]\n", argv[0]);
+            printf("\t -s SM-DS Domain\n");
+            printf("\t -i IMEI\n");
+            printf("\t -h This help info\n");
             return -1;
             break;
         }

--- a/src/applet/profile/discovery.c
+++ b/src/applet/profile/discovery.c
@@ -36,10 +36,10 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printlnf("Usage: %s [OPTIONS]", argv[0]);
-            printlnf("\t -s SM-DS Domain");
-            printlnf("\t -i IMEI");
-            printlnf("\t -h This help info");
+            printf("Usage: %s [OPTIONS]\r\n", argv[0]);
+            printf("\t -s SM-DS Domain\r\n");
+            printf("\t -i IMEI\r\n");
+            printf("\t -h This help info\r\n");
             return -1;
             break;
         }

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -91,14 +91,14 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printf("Usage: %s [OPTIONS]\r\n", argv[0]);
-            printf("\t -s SM-DP+ Domain\r\n");
-            printf("\t -m Matching ID\r\n");
-            printf("\t -i IMEI\r\n");
-            printf("\t -c Confirmation Code (Password)\r\n");
-            printf("\t -a Activation Code (e.g: 'LPA:***')\r\n");
-            printf("\t -p Interactive preview profile\r\n");
-            printf("\t -h This help info\r\n");
+            printf("Usage: %s [OPTIONS]\n", argv[0]);
+            printf("\t -s SM-DP+ Domain\n");
+            printf("\t -m Matching ID\n");
+            printf("\t -i IMEI\n");
+            printf("\t -c Confirmation Code (Password)\n");
+            printf("\t -a Activation Code (e.g: 'LPA:***')\n");
+            printf("\t -p Interactive preview profile\n");
+            printf("\t -h This help info\n");
             return -1;
         default:
             break;

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -91,14 +91,14 @@ static int applet_main(int argc, char **argv)
             break;
         case 'h':
         case '?':
-            printlnf("Usage: %s [OPTIONS]", argv[0]);
-            printlnf("\t -s SM-DP+ Domain");
-            printlnf("\t -m Matching ID");
-            printlnf("\t -i IMEI");
-            printlnf("\t -c Confirmation Code (Password)");
-            printlnf("\t -a Activation Code (e.g: 'LPA:***')");
-            printlnf("\t -p Interactive preview profile");
-            printlnf("\t -h This help info");
+            printf("Usage: %s [OPTIONS]\r\n", argv[0]);
+            printf("\t -s SM-DP+ Domain\r\n");
+            printf("\t -m Matching ID\r\n");
+            printf("\t -i IMEI\r\n");
+            printf("\t -c Confirmation Code (Password)\r\n");
+            printf("\t -a Activation Code (e.g: 'LPA:***')\r\n");
+            printf("\t -p Interactive preview profile\r\n");
+            printf("\t -h This help info\r\n");
             return -1;
         default:
             break;

--- a/src/applet/profile/enable.c
+++ b/src/applet/profile/enable.c
@@ -15,8 +15,8 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s [iccid/aid] [refreshflag]", argv[0]);
-        printlnf("\t[refreshflag]: optional");
+        printf("Usage: %s [iccid/aid] [refreshflag]\n", argv[0]);
+        printf("\t[refreshflag]: optional\n");
         return -1;
     }
 

--- a/src/applet/profile/nickname.c
+++ b/src/applet/profile/nickname.c
@@ -15,8 +15,8 @@ static int applet_main(int argc, char **argv)
 
     if (argc < 2)
     {
-        printlnf("Usage: %s [iccid] [new_name]", argv[0]);
-        printlnf("\t[new_name]: optional");
+        printf("Usage: %s [iccid] [new_name]\n", argv[0]);
+        printf("\t[new_name]: optional\n");
         return -1;
     }
 

--- a/src/jprint.c
+++ b/src/jprint.c
@@ -26,7 +26,7 @@ void jprint_error(const char *function_name, const char *detail)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printf("%s\r\n", jstr);
+    printf("%s\n", jstr);
     fflush(stdout);
     free(jstr);
 }
@@ -48,7 +48,7 @@ void jprint_progress(const char *function_name, const char *detail)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printf("%s\r\n", jstr);
+    printf("%s\n", jstr);
     fflush(stdout);
     free(jstr);
 }
@@ -77,7 +77,7 @@ void jprint_progress_obj(const char *function_name, cJSON *jdata)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printf("%s\r\n", jstr);
+    printf("%s\n", jstr);
     fflush(stdout);
     free(jstr);
 }
@@ -106,7 +106,7 @@ void jprint_success(cJSON *jdata)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printf("%s\r\n", jstr);
+    printf("%s\n", jstr);
     fflush(stdout);
     free(jstr);
 }

--- a/src/jprint.c
+++ b/src/jprint.c
@@ -26,7 +26,8 @@ void jprint_error(const char *function_name, const char *detail)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    printf("%s\r\n", jstr);
+    fflush(stdout);
     free(jstr);
 }
 
@@ -47,7 +48,8 @@ void jprint_progress(const char *function_name, const char *detail)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    printf("%s\r\n", jstr);
+    fflush(stdout);
     free(jstr);
 }
 
@@ -75,7 +77,8 @@ void jprint_progress_obj(const char *function_name, cJSON *jdata)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    printf("%s\r\n", jstr);
+    fflush(stdout);
     free(jstr);
 }
 
@@ -103,6 +106,7 @@ void jprint_success(cJSON *jdata)
     jstr = cJSON_PrintUnformatted(jroot);
     cJSON_Delete(jroot);
 
-    printlnf("%s", jstr);
+    printf("%s\r\n", jstr);
+    fflush(stdout);
     free(jstr);
 }

--- a/src/jprint.h
+++ b/src/jprint.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <cjson/cJSON_ex.h>
 
-#define fprintlnf(f, fmt, ...) fprintf(f, fmt "\n", ## __VA_ARGS__); fflush(f)
-#define printlnf(fmt, ...) fprintlnf(stdout, fmt, ## __VA_ARGS__)
-
 void jprint_error(const char *function_name, const char *detail);
 void jprint_progress(const char *function_name, const char *detail);
 void jprint_progress_obj(const char *function_name, cJSON *jdata);


### PR DESCRIPTION
> C89 Standard section 5.2.2 Character display semantics
> \n (new line) Moves the active position to the initial position of the next line.

'\n' in C have including meaning of both '\r' and '\n' on Windows, and
libc SHALL translate them when do input and output. If not, it SHALL be
a bug of libc.

FYI, all mingw64 toolchain code use '\n' directly, so it's impossible to
be caused by '\n', otherwise mingw64 itself will broken. Mingw64 also
set _fmode to _O_TEXT by default.[1] So as MSVC documents said[2], it
should do translate between LF and CRLF.

[1]: https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-crt/crt/txtmode.c
[2]: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen

Signed-off-by: Coelacanthus <uwu@coelacanthus.name>