### PR TITLE
CMakeLists.txt: enable CMAKE_EXPORT_COMPILE_COMMANDS by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(LPAC_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH ${LPAC_CMAKE_MODULE_PATH})
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # add_compile_options(-Wall -Wextra -Wpedantic)
 
 # Enable LTO when possible.
@@ -45,13 +47,13 @@ endif()
 
 if(CPACK_GENERATOR)
     set(CPACK_PACKAGE_VENDOR "eSTK.me Group")
-    
+
     set(CPACK_DEBIAN_PACKAGE_MAINTAINER "eSTK.me Group")
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6")
     set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "libcurl, libpcsclite, pcscd")
 
     set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
-    
+
     set(CPACK_RPM_PACKAGE_LICENSE "AGPL-3.0-only AND LGPL-2.0-only")
     set(CPACK_RPM_PACKAGE_AUTOREQ "yes")
     set(CPACK_RPM_PACKAGE_REQUIRES "libcurl, libpcsclite, pcscd")


### PR DESCRIPTION
This creates a `compile_commands.json` file that can then be used by the `cland` tool.