### PR TITLE
driver: apdu: qmi*: Pass correct open flag for QRTR driver

### DIFF
--- a/driver/apdu/qmi.c
+++ b/driver/apdu/qmi.c
@@ -30,7 +30,7 @@ static int apdu_interface_connect(struct euicc_ctx *ctx)
         return -1;
     }
 
-    qmi_device_open_sync(device, qmi_priv->context, &error);
+    qmi_device_open_sync(device, QMI_DEVICE_OPEN_FLAGS_PROXY, qmi_priv->context, &error);
     if (error) {
         fprintf(stderr, "error: open QMI device failed: %s\n", error->message);
         return -1;

--- a/driver/apdu/qmi_helpers.c
+++ b/driver/apdu/qmi_helpers.c
@@ -87,6 +87,7 @@ qmi_device_new_from_path(GFile *file,
 
 gboolean
 qmi_device_open_sync(QmiDevice *device,
+                     QmiDeviceOpenFlags flags,
                      GMainContext *context,
                      GError **error)
 {
@@ -96,7 +97,7 @@ qmi_device_open_sync(QmiDevice *device,
     pusher = g_main_context_pusher_new(context);
 
     qmi_device_open(device,
-                    QMI_DEVICE_OPEN_FLAGS_PROXY,
+                    flags,
                     15,
                     NULL,
                     async_result_ready,

--- a/driver/apdu/qmi_helpers.h
+++ b/driver/apdu/qmi_helpers.h
@@ -30,6 +30,7 @@ qmi_device_new_from_path(
 gboolean
 qmi_device_open_sync(
     QmiDevice *device,
+    QmiDeviceOpenFlags flags,
     GMainContext *context,
     GError **error);
 

--- a/driver/apdu/qmi_qrtr.c
+++ b/driver/apdu/qmi_qrtr.c
@@ -58,7 +58,7 @@ static int apdu_interface_connect(struct euicc_ctx *ctx)
         return -1;
     }
 
-    qmi_device_open_sync(device, qmi_priv->context, &error);
+    qmi_device_open_sync(device, QMI_DEVICE_OPEN_FLAGS_NONE, qmi_priv->context, &error);
     if (error)
     {
         fprintf(stderr, "error: open QMI device failed: %s\n", error->message);


### PR DESCRIPTION
While the QMI driver which goes to /dev/foobar wants to go through the qmi-proxy to not have to exclusively claim the device, the QMI-over-QRTR driver doesn't work with the PROXY flag and just leads to the error

  error: open QMI device failed: endpoint hangup

Fix this by passing the correct flag to qmi_device_open from both APDU drivers.

Closes: #215
Fixes: 3bde4a1 (" driver(APDU): add QMI backend (#131)")