### PR TITLE
feat: deprecated env vars

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -14,6 +14,12 @@ option(LPAC_WITH_APDU_MBIM "Build MBIM backend for MBIM devices (requires libmbi
 
 option(LPAC_WITH_HTTP_CURL "Build HTTP Curl interface" ON)
 
+option(LPAC_ENV_VARS "userdata based on environment variables" ON)
+
+if (LPAC_ENV_VARS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DLPAC_ENV_VARS")
+endif ()
+
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} DIR_INTERFACE_SRCS)
 if(LPAC_DYNAMIC_DRIVERS)
     add_library(euicc-drivers SHARED ${DIR_INTERFACE_SRCS})
@@ -24,6 +30,7 @@ endif()
 target_link_libraries(euicc-drivers euicc cjson-static)
 target_include_directories(euicc-drivers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/helpers.c)
 target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/apdu/stdio.c)
 target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/http/stdio.c)
 

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -104,6 +104,11 @@ int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name
         return -1;
     }
 
+    if (_driver_apdu->userdata != NULL)
+    {
+        euicc_driver_interface_apdu.userdata = _driver_apdu->userdata();
+    }
+
     if (_driver_apdu->init(&euicc_driver_interface_apdu))
     {
         fprintf(stderr, "APDU driver init failed\n");

--- a/driver/driver.private.h
+++ b/driver/driver.private.h
@@ -10,6 +10,7 @@ struct euicc_driver
 {
     enum euicc_driver_type type;
     const char *name;
+    void *(*userdata)();
     int (*init)(void *interface);
     int (*main)(int argc, char **argv);
     void (*fini)(void *interface);

--- a/driver/helpers.c
+++ b/driver/helpers.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef _WIN32
+static int setenv(const char *name, const char *value, int replace) {
+    if (replace != 0) goto put;
+    size_t n = 0;
+    const int errcode = getenv_s(&n, NULL, 0, name);
+    if (errcode || n) return errcode;
+put:
+    return _putenv_s(name, value);
+}
+#endif
+
+void set_deprecated_env(const char *name, const char *deprecated_name) {
+    const char *deprecated_value = getenv(deprecated_name);
+    if (deprecated_value == NULL) return; // deprecated env var not set
+    fprintf(stderr, "WARNING: Please use '%s' instead of '%s'\n", name, deprecated_name);
+    const char *value = getenv(name);
+    if (value != NULL) return; // new env var already set
+    setenv(name, deprecated_value, 1);
+}

--- a/driver/helpers.h
+++ b/driver/helpers.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define HTTP_ENV_NAME(TYPE, NAME) "LPAC_HTTP_" TYPE "_" NAME
+#define APDU_ENV_NAME(TYPE, NAME) "LPAC_APDU_" TYPE "_" NAME
+
+void set_deprecated_env(const char *name, const char *deprecated_name);


### PR DESCRIPTION
```console
$ DRIVER_IFID=1 ./lpac chip info
WARNING: Please use 'LIBEUICC_APDU_PCSC_IFID' instead of 'DRIVER_IFID'
{"type":"lpa","payload":{"code":-1,"message":"euicc_init","data":""}}
```