### PR TITLE
cmake: automatically create .gitignore in the build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
-build
 .vscode*
 .DS_Store
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,11 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(LPAC_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH ${LPAC_CMAKE_MODULE_PATH})
 
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  # Git auto-ignore out-of-source build directory
+  file(GENERATE OUTPUT .gitignore CONTENT "*")
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # add_compile_options(-Wall -Wextra -Wpedantic)


### PR DESCRIPTION
This way, every out-of-source build folder will be ignored.