### PR TITLE
Remove qmi_cleanup routine

### DIFF
--- a/driver/apdu/qmi.c
+++ b/driver/apdu/qmi.c
@@ -87,8 +87,6 @@ static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct)
 {
     struct qmi_data *qmi_priv = ifstruct->userdata;
 
-    qmi_cleanup(qmi_priv);
-
     free(qmi_priv);
 }
 

--- a/driver/apdu/qmi_common.c
+++ b/driver/apdu/qmi_common.c
@@ -151,13 +151,3 @@ void qmi_apdu_interface_disconnect(struct euicc_ctx *ctx)
     g_main_context_unref(qmi_priv->context);
     qmi_priv->context = NULL;
 }
-
-void qmi_cleanup(struct qmi_data *qmi_priv)
-{
-    if (qmi_priv->lastChannelId > 0)
-    {
-        fprintf(stderr, "Cleaning up leaked APDU channel %d\n", qmi_priv->lastChannelId);
-        qmi_apdu_interface_logic_channel_close(NULL, qmi_priv->lastChannelId);
-        qmi_priv->lastChannelId = -1;
-    }
-}

--- a/driver/apdu/qmi_common.h
+++ b/driver/apdu/qmi_common.h
@@ -18,4 +18,3 @@ int qmi_apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t *r
 int qmi_apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_t *aid, uint8_t aid_len);
 void qmi_apdu_interface_logic_channel_close(struct euicc_ctx *ctx, uint8_t channel);
 void qmi_apdu_interface_disconnect(struct euicc_ctx *ctx);
-void qmi_cleanup(struct qmi_data *qmi_priv);

--- a/driver/apdu/qmi_qrtr.c
+++ b/driver/apdu/qmi_qrtr.c
@@ -122,8 +122,6 @@ static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct)
 {
     struct qmi_data *qmi_priv = ifstruct->userdata;
 
-    qmi_cleanup(qmi_priv);
-
     free(qmi_priv);
 }
 


### PR DESCRIPTION
`qmi_apdu_interface_logic_channel_close()` called from within `main_fini_euicc()` should already close the channel and invalidate the `qmi_priv->lastChannelId` variable.