### PR TITLE
driver: apdu: at: don't expect space after "+CGLA:"

### DIFF
--- a/driver/apdu/at.c
+++ b/driver/apdu/at.c
@@ -113,7 +113,7 @@ static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t
         fprintf(fuart, "%02X", (uint8_t)(tx[i] & 0xFF));
     }
     fprintf(fuart, "\"\r\n");
-    if (at_expect(&response, "+CGLA: "))
+    if (at_expect(&response, "+CGLA:"))
     {
         goto err;
     }


### PR DESCRIPTION
Some devices have a difference in format and do not add a space.

Simcom A7908E:
  AT+CGLA=1,16,"81E2910003BF3C00"
  +CGLA:4,"611A"

  OK