### PR TITLE
driver: apdu: mbim: sleep while waiting for sim

### DIFF
--- a/driver/apdu/mbim.c
+++ b/driver/apdu/mbim.c
@@ -107,6 +107,11 @@ static int select_sim_slot(struct mbim_data *mbim_priv)
         if (is_sim_available(mbim_priv)) {
             return 0;
         }
+        struct timespec ts = {
+            .tv_sec = 0,
+            .tv_nsec = 50000000
+        };
+        nanosleep(&ts, NULL);
     }
 
     fprintf(stderr, "sim did not become available\n");


### PR DESCRIPTION
When waiting for the sim to become available after potentially switching, we don't actually do much waiting. We're basically only delayed by the speed of the communication here. If the switch doesn't happen quickly enough, this may result in us deciding a sim didn't become available, but subsequent calls will produce usable results.

So introduce a small 50 ms wait time, so we limit the total waiting time to about 1 second. This I think should be enough for the sim to actually become available.

resolve #241