### PR TITLE
driver: apdu: mbim: make sim behavior more consistent

### DIFF
--- a/driver/apdu/mbim.c
+++ b/driver/apdu/mbim.c
@@ -105,7 +105,7 @@ static int select_sim_slot(struct mbim_data *mbim_priv)
     int retries = 20;
     while (retries--) {
         if (is_sim_available(mbim_priv)) {
-            return 0;
+            break;
         }
         struct timespec ts = {
             .tv_sec = 0,
@@ -114,8 +114,7 @@ static int select_sim_slot(struct mbim_data *mbim_priv)
         nanosleep(&ts, NULL);
     }
 
-    fprintf(stderr, "sim did not become available\n");
-    return -1;
+    return 0;
 }
 
 static int apdu_interface_connect(struct euicc_ctx *ctx)


### PR DESCRIPTION
When we do not need to switch sims, the output of the program says

    error: no channel response received: Failure

but when we do switch, we say

    sim did not become available

To make this behavior more consistent, don't say anything about the sim status and continue as if we didn't have to switch.