### PR TITLE
refactor: move fallback logic to _find_driver()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -159,22 +159,12 @@ static char **warg_to_arg(const int wargc, wchar_t **wargv)
 int main(int argc, char **argv)
 {
     int ret = 0;
-    const char *apdu_driver;
-    const char *http_driver;
 
     memset(&euicc_ctx, 0, sizeof(euicc_ctx));
 
-    apdu_driver = getenv(ENV_APDU_DRIVER);
-    if (apdu_driver == NULL)
-    {
-        apdu_driver = "pcsc";
-    }
+    const char *apdu_driver = getenv(ENV_APDU_DRIVER);
 
-    http_driver = getenv(ENV_HTTP_DRIVER);
-    if (http_driver == NULL)
-    {
-        http_driver = "curl";
-    }
+    const char *http_driver = getenv(ENV_HTTP_DRIVER);
 
     if (euicc_driver_init(apdu_driver, http_driver))
     {


### PR DESCRIPTION
if driver name is NULL then select first available driver

https://github.com/estkme-group/lpac/blob/0fd05d039eaab1b4ab8ecd7c38c439aef9f18da4/driver/driver.c#L76-L95