### PR TITLE
feat: strict matching id checking in activation code

### DIFF
--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -1,6 +1,7 @@
 #include "download.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
 #include <getopt.h>
@@ -36,6 +37,21 @@ char *strsep(char **stringp, const char *__delim) {
     return rv;
 }
 #endif
+
+static bool is_strict_matching_id(const char *token) {
+    const size_t n = strlen(token);
+    bool allowed = false;
+    for (int i = 0; i < n; i++) {
+        allowed = (
+            (token[i] >= '0' && token[i] <= '9') ||
+            (token[i] >= 'a' && token[i] <= 'z') ||
+            (token[i] >= 'A' && token[i] <= 'Z') ||
+            (token[i] == '-')
+        );
+        if (!allowed) return false;
+    }
+    return true;
+}
 
 static void sigint_handler(int x)
 {
@@ -144,6 +160,11 @@ static int applet_main(int argc, char **argv)
                 break;
             case 2: // AC_Token or Matching ID
                 matchingId = strdup(token);
+                if (!is_strict_matching_id(matchingId)) {
+                    error_function_name = "matching_id";
+                    error_detail = "invalid format";
+                    goto err;
+                }
                 break;
             case 3: // SM-DP+ OID
                 // ignored; this function is not implemented

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -1,4 +1,6 @@
 #include "download.h"
+
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -40,15 +42,9 @@ char *strsep(char **stringp, const char *__delim) {
 
 static bool is_strict_matching_id(const char *token) {
     const size_t n = strlen(token);
-    bool allowed = false;
     for (int i = 0; i < n; i++) {
-        allowed = (
-            (token[i] >= '0' && token[i] <= '9') ||
-            (token[i] >= 'a' && token[i] <= 'z') ||
-            (token[i] >= 'A' && token[i] <= 'Z') ||
-            (token[i] == '-')
-        );
-        if (!allowed) return false;
+        if (isalnum(token[i]) || token[i] == '-') continue;
+        return false;
     }
     return true;
 }
@@ -162,7 +158,7 @@ static int applet_main(int argc, char **argv)
                 matchingId = strdup(token);
                 if (!is_strict_matching_id(matchingId)) {
                     error_function_name = "matching_id";
-                    error_detail = "invalid format";
+                    error_detail = "invalid format, contains character not alphanumeric or dash";
                     goto err;
                 }
                 break;

--- a/src/main.c
+++ b/src/main.c
@@ -3,9 +3,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <time.h>
+#include <locale.h>
 
-#include <euicc/interface.h>
 #include <euicc/hexutil.h>
 #include <euicc/euicc.h>
 #include <driver.h>
@@ -163,6 +162,8 @@ static char **warg_to_arg(const int wargc, wchar_t **wargv)
 int main(int argc, char **argv)
 {
     int ret = 0;
+
+    setlocale(LC_ALL, "C.UTF-8");
 
     memset(&euicc_ctx, 0, sizeof(euicc_ctx));
 


### PR DESCRIPTION
```console
$ ./lpac profile download -a $'LPA:1\$example.com\$test\ntest'
{"type":"progress","payload":{"code":0,"message":"es10b_cancel_session","data":"example.com"}}
{"type":"progress","payload":{"code":0,"message":"es9p_cancel_session","data":"example.com"}}
{"type":"lpa","payload":{"code":-1,"message":"matching_id","data":"invalid format, contains character not alphanumeric or dash"}}
```