### PR TITLE
docs: update openwrt minimum available release

### DIFF
--- a/docs/LINUX-DIST.md
+++ b/docs/LINUX-DIST.md
@@ -6,7 +6,7 @@
 
 ## OpenWrt
 
-> Minimum available release: Snapshot
+> Minimum available release: [24.10.2](https://downloads.openwrt.org/releases/24.10.2/targets/)
 > (Added on 2024-05-15)
 
 ```shell


### PR DESCRIPTION
proof: https://downloads.openwrt.org/releases/24.10.2/packages/x86_64/packages/lpac_2.1.0-r1_x86_64.ipk