### PR TITLE
fix(git-blame-ignore-revs): fix wrong commit id broken by stupid GitHub

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-# chore(format): reformat all code 2025-08-15 23:07:07 +0800
-1dcc470cbf5f3c09378e850ce3c91116fbae1bff
+# chore(format): reformat all code 2025-08-15 23:11:39 +0800
+62f54d429a028c69361af80151fd46782236a1c3


### PR DESCRIPTION
GitHub's rebase merge won't do fast forward merge even when they can do!!!