### PR TITLE
chore(driver): cleanup unused main functions

### DIFF
--- a/driver/apdu/gbinder_hidl.c
+++ b/driver/apdu/gbinder_hidl.c
@@ -291,14 +291,12 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct) {
     return 0;
 }
 
-static int libapduinterface_main(int argc, char **argv) { return 0; }
-
 static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct) {}
 
 const struct euicc_driver driver_apdu_gbinder_hidl = {
     .type = DRIVER_APDU,
     .name = "gbinder_hidl",
     .init = (int (*)(void *))libapduinterface_init,
-    .main = libapduinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libapduinterface_fini,
 };

--- a/driver/apdu/mbim.c
+++ b/driver/apdu/mbim.c
@@ -303,14 +303,12 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct) {
     return 0;
 }
 
-static int libapduinterface_main(int argc, char **argv) { return 0; }
-
 static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct) { g_free(ifstruct->userdata); }
 
 const struct euicc_driver driver_apdu_mbim = {
     .type = DRIVER_APDU,
     .name = "mbim",
     .init = (int (*)(void *))libapduinterface_init,
-    .main = libapduinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libapduinterface_fini,
 };

--- a/driver/apdu/qmi.c
+++ b/driver/apdu/qmi.c
@@ -235,8 +235,6 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct) {
     return 0;
 }
 
-static int libapduinterface_main(int argc, char **argv) { return 0; }
-
 static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct) {
     struct qmi_data *qmi_priv = ifstruct->userdata;
 
@@ -249,6 +247,6 @@ const struct euicc_driver driver_apdu_qmi = {
     .type = DRIVER_APDU,
     .name = "qmi",
     .init = (int (*)(void *))libapduinterface_init,
-    .main = libapduinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libapduinterface_fini,
 };

--- a/driver/apdu/qmi_qrtr.c
+++ b/driver/apdu/qmi_qrtr.c
@@ -101,8 +101,6 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct) {
     return 0;
 }
 
-static int libapduinterface_main(int argc, char **argv) { return 0; }
-
 static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct) {
     struct qmi_data *qmi_priv = ifstruct->userdata;
 
@@ -115,6 +113,6 @@ const struct euicc_driver driver_apdu_qmi_qrtr = {
     .type = DRIVER_APDU,
     .name = "qmi_qrtr",
     .init = (int (*)(void *))libapduinterface_init,
-    .main = libapduinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libapduinterface_fini,
 };

--- a/driver/apdu/stdio.c
+++ b/driver/apdu/stdio.c
@@ -230,14 +230,12 @@ static int libapduinterface_init(struct euicc_apdu_interface *ifstruct) {
     return 0;
 }
 
-static int libapduinterface_main(const struct euicc_apdu_interface *ifstruct, int argc, char **argv) { return 0; }
-
 static void libapduinterface_fini(struct euicc_apdu_interface *ifstruct) {}
 
 const struct euicc_driver driver_apdu_stdio = {
     .type = DRIVER_APDU,
     .name = "stdio",
     .init = (int (*)(void *))libapduinterface_init,
-    .main = (int (*)(void *, int, char **))libapduinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libapduinterface_fini,
 };

--- a/driver/http/curl.c
+++ b/driver/http/curl.c
@@ -174,14 +174,12 @@ static int libhttpinterface_init(struct euicc_http_interface *ifstruct) {
     return 0;
 }
 
-static int libhttpinterface_main(struct euicc_http_interface *ifstruct, int argc, char **argv) { return 0; }
-
 static void libhttpinterface_fini(struct euicc_http_interface *ifstruct) {}
 
 const struct euicc_driver driver_http_curl = {
     .type = DRIVER_HTTP,
     .name = "curl",
     .init = (int (*)(void *))libhttpinterface_init,
-    .main = (int (*)(void *, int, char **))libhttpinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libhttpinterface_fini,
 };

--- a/driver/http/stdio.c
+++ b/driver/http/stdio.c
@@ -175,14 +175,12 @@ static int libhttpinterface_init(struct euicc_http_interface *ifstruct) {
     return 0;
 }
 
-static int libhttpinterface_main(struct euicc_http_interface *ifstruct, int argc, char **argv) { return 0; }
-
 static void libhttpinterface_fini(struct euicc_http_interface *ifstruct) {}
 
 const struct euicc_driver driver_http_stdio = {
     .type = DRIVER_HTTP,
     .name = "stdio",
     .init = (int (*)(void *))libhttpinterface_init,
-    .main = (int (*)(void *, int, char **))libhttpinterface_main,
+    .main = NULL,
     .fini = (void (*)(void *))libhttpinterface_fini,
 };


### PR DESCRIPTION
```console
$ LPAC_APDU=stdio ./lpac driver apdu
The APDU driver 'stdio' does not support main function
```