### PR TITLE
chore(treewide): remove -Werror and -pedantic

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
 endif()
 target_link_libraries(euicc-drivers euicc cjson-static lpac-utils)
 target_include_directories(euicc-drivers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(euicc-drivers PRIVATE -Werror)
 
 target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/apdu/stdio.c)
 target_sources(euicc-drivers PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/http/stdio.c)

--- a/euicc/CMakeLists.txt
+++ b/euicc/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 target_link_libraries(euicc cjson-static)
 target_include_directories(euicc PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
-target_compile_options(euicc PRIVATE -Wall -Werror -Wextra -pedantic)
+target_compile_options(euicc PRIVATE -Wall -Wextra)
 if(LPAC_DYNAMIC_LIBEUICC)
     # Install headers
     file(GLOB ALL_HEADERS "*.h")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet/profile DIR_LPAC_SRCS)
 add_executable(lpac ${DIR_LPAC_SRCS} lpac.manifest)
 target_link_libraries(lpac euicc-drivers lpac-utils)
 target_include_directories(lpac PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_compile_options(lpac PRIVATE -Wall -Werror -Wextra -pedantic)
+target_compile_options(lpac PRIVATE -Wall -Wextra)
 
 find_package(Git)
 add_custom_target(version

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(lpac-utils OBJECT lpac/utils.c)
 target_include_directories(lpac-utils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(lpac-utils PRIVATE cjson-static euicc)
+target_compile_options(lpac-utils PRIVATE -Wall -Wextra)


### PR DESCRIPTION
* -Werror should only be enabled in testing or develop environment.
* -pendantic may warn when we use POSIX or GNU extension.