### PR TITLE
fix(main): ensure lpac driver list skips init

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet DIR_LPAC_SRCS)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet/chip DIR_LPAC_SRCS)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet/notification DIR_LPAC_SRCS)
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet/profile DIR_LPAC_SRCS)
+aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/applet/driver DIR_LPAC_SRCS)
 
 add_executable(lpac ${DIR_LPAC_SRCS} lpac.manifest)
 target_link_libraries(lpac euicc-drivers lpac-utils)

--- a/src/applet.c
+++ b/src/applet.c
@@ -1,7 +1,10 @@
 #include "applet.h"
-
+#include <driver.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <lpac/utils.h>
+#include <main.h>
 
 static void applet_usage(const char *selfname, const struct applet_entry **entries) {
     const struct applet_entry *entry;
@@ -19,19 +22,37 @@ static void applet_usage(const char *selfname, const struct applet_entry **entri
 }
 
 int applet_entry(int argc, char **argv, const struct applet_entry **entries) {
-    const struct applet_entry **entries_cpy;
+    const struct applet_entry **ptr = entries;
     const struct applet_entry *entry;
-
-    entries_cpy = entries;
 
     if (argc < 2) {
         applet_usage(argv[0], entries);
         return -1;
     }
 
-    while ((entry = *entries_cpy++)) {
+    while ((entry = *ptr++)) {
         if (strcmp(argv[1], entry->name) == 0) {
-            return entry->main(argc - 1, argv + 1);
+            if (entry->subapplets && argc > 2) {
+                return applet_entry(argc - 1, argv + 1, entry->subapplets);
+            }
+
+            if (entry->main) {
+                if (!entry->skip_init_driver) {
+                    if (euicc_driver_init(getenv(ENV_APDU_DRIVER), getenv(ENV_HTTP_DRIVER))) {
+                        fprintf(stderr, "euicc_driver_init failed\n");
+                        return -1;
+                    }
+                }
+                if (!entry->skip_init_euicc) {
+                    const int ret = main_init_euicc();
+                    if (ret != 0)
+                        return ret;
+                }
+                return entry->main(argc - 1, argv + 1);
+            }
+
+            applet_usage(argv[0], entry->subapplets ? entry->subapplets : entries);
+            return -1;
         }
     }
 

--- a/src/applet.c
+++ b/src/applet.c
@@ -1,10 +1,10 @@
 #include "applet.h"
 #include <driver.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <lpac/utils.h>
 #include <main.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 static void applet_usage(const char *selfname, const struct applet_entry **entries) {
     const struct applet_entry *entry;

--- a/src/applet.h
+++ b/src/applet.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <stdbool.h>
+
 struct applet_entry {
     const char *name;
     int (*main)(int argc, char **argv);
+    bool skip_init_driver;
+    bool skip_init_euicc;
+    const struct applet_entry **subapplets;
 };
 
 int applet_entry(int argc, char **argv, const struct applet_entry **entries);

--- a/src/applet/chip.c
+++ b/src/applet/chip.c
@@ -3,12 +3,8 @@
 #include "chip/defaultsmdp.h"
 #include "chip/info.h"
 #include "chip/purge.h"
-#include "main.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <stddef.h>
 
 static const struct applet_entry *applets[] = {
     &applet_chip_info,
@@ -17,14 +13,8 @@ static const struct applet_entry *applets[] = {
     NULL,
 };
 
-static int applet_main(const int argc, char **argv) {
-    const int ret = main_init_euicc();
-    if (ret != 0)
-        return ret;
-    return applet_entry(argc, argv, applets);
-}
-
 struct applet_entry applet_chip = {
     .name = "chip",
-    .main = applet_main,
+    .main = NULL,
+    .subapplets = applets,
 };

--- a/src/applet/driver.c
+++ b/src/applet/driver.c
@@ -4,12 +4,26 @@
 #include <jprint.h>
 #include <stddef.h>
 
-const struct applet_entry applet_apdu = {.name = "apdu", .main = euicc_driver_main_apdu, .skip_init_euicc = true};
+// clang-format off
+const struct applet_entry applet_apdu = {
+    .name = "apdu",
+    .main = euicc_driver_main_apdu,
+    .skip_init_euicc = true
+};
 
-const struct applet_entry applet_http = {.name = "http", .main = euicc_driver_main_http, .skip_init_euicc = true};
+const struct applet_entry applet_http = {
+    .name = "http",
+    .main = euicc_driver_main_http,
+    .skip_init_euicc = true
+};
 
 const struct applet_entry applet_list = {
-    .name = "list", .main = euicc_driver_list, .skip_init_driver = true, .skip_init_euicc = true};
+    .name = "list",
+    .main = euicc_driver_list,
+    .skip_init_driver = true,
+    .skip_init_euicc = true
+};
+// clang-format on
 
 const struct applet_entry *applets[] = {
     &applet_apdu,

--- a/src/applet/driver.c
+++ b/src/applet/driver.c
@@ -1,0 +1,38 @@
+#include <driver.h>
+#include <cjson/cJSON_ex.h>
+#include <jprint.h>
+#include <stddef.h>
+#include <applet.h>
+
+
+const struct applet_entry applet_apdu = {
+    .name = "apdu",
+    .main = euicc_driver_main_apdu,
+    .skip_init_euicc = true
+};
+
+const struct applet_entry applet_http = {
+    .name = "http",
+    .main = euicc_driver_main_http,
+    .skip_init_euicc = true
+};
+
+const struct applet_entry applet_list = {
+    .name = "list",
+    .main = euicc_driver_list,
+    .skip_init_driver = true,
+    .skip_init_euicc = true
+};
+
+const struct applet_entry *applets[] = {
+    &applet_apdu,
+    &applet_http,
+    &applet_list,
+    NULL,
+};
+
+struct applet_entry applet_driver = {
+    .name = "driver",
+    .main = NULL,
+    .subapplets = applets,
+};

--- a/src/applet/driver.c
+++ b/src/applet/driver.c
@@ -1,28 +1,15 @@
-#include <driver.h>
+#include <applet.h>
 #include <cjson/cJSON_ex.h>
+#include <driver.h>
 #include <jprint.h>
 #include <stddef.h>
-#include <applet.h>
 
+const struct applet_entry applet_apdu = {.name = "apdu", .main = euicc_driver_main_apdu, .skip_init_euicc = true};
 
-const struct applet_entry applet_apdu = {
-    .name = "apdu",
-    .main = euicc_driver_main_apdu,
-    .skip_init_euicc = true
-};
-
-const struct applet_entry applet_http = {
-    .name = "http",
-    .main = euicc_driver_main_http,
-    .skip_init_euicc = true
-};
+const struct applet_entry applet_http = {.name = "http", .main = euicc_driver_main_http, .skip_init_euicc = true};
 
 const struct applet_entry applet_list = {
-    .name = "list",
-    .main = euicc_driver_list,
-    .skip_init_driver = true,
-    .skip_init_euicc = true
-};
+    .name = "list", .main = euicc_driver_list, .skip_init_driver = true, .skip_init_euicc = true};
 
 const struct applet_entry *applets[] = {
     &applet_apdu,

--- a/src/applet/drivre.h
+++ b/src/applet/drivre.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "driver.h"
+
+#include <applet.h>
+
+extern struct applet_entry applet_driver;

--- a/src/applet/notification.c
+++ b/src/applet/notification.c
@@ -1,30 +1,20 @@
 #include "notification.h"
 
-#include "main.h"
 #include "notification/dump.h"
 #include "notification/list.h"
 #include "notification/process.h"
 #include "notification/remove.h"
 #include "notification/replay.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <stddef.h>
 
 static const struct applet_entry *applets[] = {
     &applet_notification_list, &applet_notification_process, &applet_notification_remove,
     &applet_notification_dump, &applet_notification_replay,  NULL,
 };
 
-static int applet_main(const int argc, char **argv) {
-    const int ret = main_init_euicc();
-    if (ret != 0)
-        return ret;
-    return applet_entry(argc, argv, applets);
-}
-
 struct applet_entry applet_notification = {
     .name = "notification",
-    .main = applet_main,
+    .main = NULL,
+    .subapplets = applets,
 };

--- a/src/applet/profile.c
+++ b/src/applet/profile.c
@@ -1,6 +1,5 @@
 #include "profile.h"
 
-#include "main.h"
 #include "profile/delete.h"
 #include "profile/disable.h"
 #include "profile/discovery.h"
@@ -9,24 +8,15 @@
 #include "profile/list.h"
 #include "profile/nickname.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+#include <stddef.h>
 
 static const struct applet_entry *applets[] = {
     &applet_profile_list,   &applet_profile_enable,   &applet_profile_disable,   &applet_profile_nickname,
     &applet_profile_delete, &applet_profile_download, &applet_profile_discovery, NULL,
 };
 
-static int applet_main(const int argc, char **argv) {
-    const int ret = main_init_euicc();
-    if (ret != 0)
-        return ret;
-    return applet_entry(argc, argv, applets);
-}
-
 struct applet_entry applet_profile = {
     .name = "profile",
-    .main = applet_main,
+    .main = NULL,
+    .subapplets = applets,
 };

--- a/src/applet/version.c
+++ b/src/applet/version.c
@@ -1,7 +1,7 @@
 #include "version.h"
-#include <stddef.h>
 #include <cjson/cJSON_ex.h>
 #include <jprint.h>
+#include <stddef.h>
 
 #ifndef LPAC_VERSION
 #    define LPAC_VERSION "v0.0.0-unknown"

--- a/src/applet/version.c
+++ b/src/applet/version.c
@@ -1,5 +1,7 @@
 #include "version.h"
-#include "main.h"
+#include <stddef.h>
+#include <cjson/cJSON_ex.h>
+#include <jprint.h>
 
 #ifndef LPAC_VERSION
 #    define LPAC_VERSION "v0.0.0-unknown"
@@ -13,4 +15,7 @@ static int applet_main(__attribute__((unused)) int argc, __attribute__((unused))
 struct applet_entry applet_version = {
     .name = "version",
     .main = applet_main,
+    .skip_init_driver = true,
+    .skip_init_euicc = true,
+    .subapplets = NULL,
 };

--- a/src/main.c
+++ b/src/main.c
@@ -34,16 +34,8 @@
 #define ES10X_MSS_MAX_VALUE 255
 
 static const struct applet_entry *driver_applets[] = {
-    &(struct applet_entry){
-        .name = "apdu",
-        .main = euicc_driver_main_apdu,
-        .skip_init_euicc = true
-    },
-    &(struct applet_entry){
-        .name = "http",
-        .main = euicc_driver_main_http,
-        .skip_init_euicc = true
-    },
+    &(struct applet_entry){.name = "apdu", .main = euicc_driver_main_apdu, .skip_init_euicc = true},
+    &(struct applet_entry){.name = "http", .main = euicc_driver_main_http, .skip_init_euicc = true},
     &(struct applet_entry){
         .name = "list",
         .main = euicc_driver_list,
@@ -159,7 +151,6 @@ int main(int argc, char **argv) {
 
     euicc_ctx.apdu.interface = &euicc_driver_interface_apdu;
     euicc_ctx.http.interface = &euicc_driver_interface_http;
-
 
 #ifdef WIN32
     argv = warg_to_arg(argc, CommandLineToArgvW(GetCommandLineW(), &argc));

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 #include "applet/notification.h"
 #include "applet/profile.h"
 #include "applet/version.h"
+#include "applet/drivre.h"
 
 #include <locale.h>
 #include <stdio.h>
@@ -33,26 +34,10 @@
 #define ES10X_MSS_MIN_VALUE 6
 #define ES10X_MSS_MAX_VALUE 255
 
-static const struct applet_entry *driver_applets[] = {
-    &(struct applet_entry){.name = "apdu", .main = euicc_driver_main_apdu, .skip_init_euicc = true},
-    &(struct applet_entry){.name = "http", .main = euicc_driver_main_http, .skip_init_euicc = true},
-    &(struct applet_entry){
-        .name = "list",
-        .main = euicc_driver_list,
-        .skip_init_driver = true,
-        .skip_init_euicc = true,
-    },
-    NULL,
-};
 
-struct applet_entry driver_applet = {
-    .name = "driver",
-    .main = NULL,
-    .subapplets = driver_applets,
-};
 
 static const struct applet_entry *applets[] = {
-    &driver_applet, &applet_chip, &applet_profile, &applet_notification, &applet_version, NULL,
+    &applet_driver, &applet_chip, &applet_profile, &applet_notification, &applet_version, NULL,
 };
 
 static int euicc_ctx_inited = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -2,10 +2,10 @@
 
 #include "applet.h"
 #include "applet/chip.h"
+#include "applet/drivre.h"
 #include "applet/notification.h"
 #include "applet/profile.h"
 #include "applet/version.h"
-#include "applet/drivre.h"
 
 #include <locale.h>
 #include <stdio.h>
@@ -33,8 +33,6 @@
 #define ENV_ES10X_MSS CUSTOM_ENV_NAME(ES10X_MSS)
 #define ES10X_MSS_MIN_VALUE 6
 #define ES10X_MSS_MAX_VALUE 255
-
-
 
 static const struct applet_entry *applets[] = {
     &applet_driver, &applet_chip, &applet_profile, &applet_notification, &applet_version, NULL,

--- a/src/main.c
+++ b/src/main.c
@@ -159,12 +159,13 @@ int main(int argc, char **argv) {
 
     const char *http_driver = getenv(ENV_HTTP_DRIVER);
 
-    if (euicc_driver_init(apdu_driver, http_driver)) {
-        return -1;
+    if (!(argc >= 3 && strcmp(argv[1], "driver") == 0 && strcmp(argv[2], "list") == 0)) {
+        if (euicc_driver_init(apdu_driver, http_driver)) {
+            return -1;
+        }
+        euicc_ctx.apdu.interface = &euicc_driver_interface_apdu;
+        euicc_ctx.http.interface = &euicc_driver_interface_http;
     }
-
-    euicc_ctx.apdu.interface = &euicc_driver_interface_apdu;
-    euicc_ctx.http.interface = &euicc_driver_interface_http;
 
 #ifdef WIN32
     argv = warg_to_arg(argc, CommandLineToArgvW(GetCommandLineW(), &argc));


### PR DESCRIPTION
Before the repair:  
```
[root@XiaPuPC output]# ./lpac driver list
SCardEstablishContext() failed: 8010001D (Unknown error: 0xFFFFFFFF8010001D)
APDU driver init failed
```  
After the repair:  
```
[root@XiaPuPC output]# ./lpac driver list
{"type":"driver","payload":{"LPAC_APDU":["pcsc","at","stdio"],"LPAC_HTTP":["curl","stdio"]}}
```