### PR TITLE
fix(cJSON): invoke wrong memory release function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,9 @@ if (NOT DEFINED USE_SYSTEM_DEPS)
             set(ENABLE_CUSTOM_COMPILER_FLAGS OFF)
             FetchContent_MakeAvailable(cjson)
             set(CJSON_LIBRARY cjson)
+            # Force cJSON dynamically link CRT although it's statuc library.
+            set_property(TARGET cjson PROPERTY
+                MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
         else()
             message(FATAL_ERROR "System cJSON is not found and network access is not permitted!")
         endif()
@@ -100,6 +103,9 @@ else()
         set(ENABLE_CUSTOM_COMPILER_FLAGS OFF)
         FetchContent_MakeAvailable(cjson)
         set(CJSON_LIBRARY cjson)
+        # Force cJSON dynamically link CRT although it's statuc library.
+        set_property(TARGET cjson PROPERTY
+            MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
     else()
         message(FATAL_ERROR "System cJSON is not found and network access is not permitted!")
     endif()

--- a/src/applet/notification/dump.c
+++ b/src/applet/notification/dump.c
@@ -24,7 +24,7 @@ static bool retrieve_notification(const char *eid, const uint32_t seqNumber) {
     if (jroot == NULL)
         return false;
 
-    _cleanup_free_ char *jstr = cJSON_PrintUnformatted(jroot);
+    _cleanup_cjson_free_ char *jstr = cJSON_PrintUnformatted(jroot);
     printf("%s\n", jstr);
     fflush(stdout);
 

--- a/src/jprint.c
+++ b/src/jprint.c
@@ -10,7 +10,7 @@
 void jprint_error(const char *function_name, const char *detail) {
     _cleanup_cjson_ cJSON *jroot = NULL;
     cJSON *jpayload = NULL;
-    _cleanup_free_ char *jstr = NULL;
+    _cleanup_cjson_free_ char *jstr = NULL;
 
     if (detail == NULL) {
         detail = "";
@@ -33,7 +33,7 @@ void jprint_error(const char *function_name, const char *detail) {
 void jprint_progress(const char *function_name, const char *detail) {
     _cleanup_cjson_ cJSON *jroot = NULL;
     cJSON *jpayload = NULL;
-    _cleanup_free_ char *jstr = NULL;
+    _cleanup_cjson_free_ char *jstr = NULL;
 
     jroot = cJSON_CreateObject();
     cJSON_AddStringOrNullToObject(jroot, "type", "progress");
@@ -52,7 +52,7 @@ void jprint_progress(const char *function_name, const char *detail) {
 void jprint_progress_obj(const char *function_name, cJSON *jdata) {
     _cleanup_cjson_ cJSON *jroot = NULL;
     cJSON *jpayload = NULL;
-    _cleanup_free_ char *jstr = NULL;
+    _cleanup_cjson_free_ char *jstr = NULL;
 
     jroot = cJSON_CreateObject();
     cJSON_AddStringOrNullToObject(jroot, "type", "progress");
@@ -75,7 +75,7 @@ void jprint_progress_obj(const char *function_name, cJSON *jdata) {
 void jprint_success(cJSON *jdata) {
     _cleanup_cjson_ cJSON *jroot = NULL;
     cJSON *jpayload = NULL;
-    _cleanup_free_ char *jstr = NULL;
+    _cleanup_cjson_free_ char *jstr = NULL;
 
     jroot = cJSON_CreateObject();
     cJSON_AddStringOrNullToObject(jroot, "type", "lpa");

--- a/utils/lpac/utils.c
+++ b/utils/lpac/utils.c
@@ -57,7 +57,7 @@ void set_deprecated_env_name(const char *name, const char *deprecated_name) {
 
 bool json_print(char *type, cJSON *jpayload) {
     _cleanup_cjson_ cJSON *jroot = NULL;
-    _cleanup_free_ char *jstr = NULL;
+    _cleanup_cjson_free_ char *jstr = NULL;
 
     if (jpayload == NULL) {
         goto err;

--- a/utils/lpac/utils.h
+++ b/utils/lpac/utils.h
@@ -27,6 +27,9 @@
 DEFINE_TRIVIAL_CLEANUP_FUNC(cJSON *, cJSON_Delete);
 #define _cleanup_cjson_ _cleanup_(cJSON_Deletep)
 
+static inline void cJSON_freep(void *p) { cJSON_free(*(void **)p); }
+#define _cleanup_cjson_free_ _cleanup_(cJSON_freep)
+
 DEFINE_TRIVIAL_CLEANUP_FUNC(struct es10b_notification_metadata_list *, es10b_notification_metadata_list_free_all);
 #define _cleanup_es10b_notification_metadata_list_ _cleanup_(es10b_notification_metadata_list_free_allp)
 


### PR DESCRIPTION
F**king cJSON library has almost no documentation. There is no one who will tell you the internal allocator will be used to allocate the string returned by cJSON_Print* series functions, and it SHALL be released using cJSON_free() to pair with the allocator!

And Windows has a different behavior from *nix. On *nix, although the library is built as a static library, the libc is still dynamically linked. But on Windows, it will statically link the CRT by default. It will lead there are two different instances of CRT, and then the malloc()/free() seen by cjson and other parts of lpac
are different.

supersedes and close #328