### PR TITLE
refactor(cmake): move some options to global

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,12 @@ project (lpac
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+include(CMakeDependentOption)
 option(USE_SYSTEM_DEPS "Use system-wide installed dependencies" OFF)
+option(LPAC_DYNAMIC_LIBEUICC "Build and install libeuicc as a dynamic library" OFF)
+cmake_dependent_option(LPAC_DYNAMIC_DRIVERS "Build lpac/libeuicc driver backends as a dynamic library" ON "LPAC_DYNAMIC_LIBEUICC" OFF)
+cmake_dependent_option(LPAC_DYNAMIC_DRIVERS_SOLID "Build lpac/libeuicc driver backends as a solid dynamic library" OFF "LPAC_DYNAMIC_LIBEUICC AND LPAC_DYNAMIC_DRIVERS" OFF)
+
 
 set(LPAC_CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH ${LPAC_CMAKE_MODULE_PATH})

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -1,7 +1,3 @@
-include(CMakeDependentOption)
-cmake_dependent_option(LPAC_DYNAMIC_DRIVERS "Build lpac/libeuicc driver backends as a dynamic library" ON "LPAC_DYNAMIC_LIBEUICC" OFF)
-cmake_dependent_option(LPAC_DYNAMIC_DRIVERS_SOLID "Build lpac/libeuicc driver backends as a solid dynamic library" OFF "LPAC_DYNAMIC_LIBEUICC AND LPAC_DYNAMIC_DRIVERS" OFF)
-
 option(LPAC_WITH_APDU_PCSC "Build APDU PCSC Backend (requires PCSC libraries)" ON)
 option(LPAC_WITH_APDU_AT "Build APDU AT Backend" ON)
 option(LPAC_WITH_APDU_GBINDER "Build APDU Gbinder backend for libhybris devices (requires gbinder headers)" OFF)

--- a/euicc/CMakeLists.txt
+++ b/euicc/CMakeLists.txt
@@ -1,4 +1,3 @@
-option(LPAC_DYNAMIC_LIBEUICC "Build and install libeuicc as a dynamic library" OFF)
 option(LIBEUICC_REDUCED_STDLIB_CALL "Reduce standard library calling" OFF)
 
 if(LPAC_DYNAMIC_LIBEUICC)


### PR DESCRIPTION
So it can be used by lpac-utils.