### PR TITLE
docs(docs/at): add caveats

### DIFF
--- a/docs/backends/at.md
+++ b/docs/backends/at.md
@@ -29,9 +29,10 @@ If you need to allow **non-root** users to access serial ports, read the followi
 3. <https://wiki.archlinux.org/title/Working_with_the_serial_console#Connect_using_a_terminal_emulator_program>
    (Arch Linux)
 
-> [!NOTE]
->
-> If you encounter the `+CME ERROR: 3` issue, this may be related to device internal settings. Please contact the device admin or support team for instructions on how to resolve it.
+## Caveats
+
+- If you encounter the `+CME ERROR: 3` (Operation not allowed) issue, this may be related to device internal settings. \
+  Please contact this modem FAE for instructions on how to resolve it.
 
 ## `at` Backend
 


### PR DESCRIPTION
For equipment from some manufacturers, SIM card sleep must be disabled by issuing the `AT+ECSIMSLEEP=0` command before executing SIM-related commands such as `AT+CSIM`.