### PR TITLE
fix(driver/mbim): better support for single slot devices

### DIFF
--- a/driver/apdu/mbim.c
+++ b/driver/apdu/mbim.c
@@ -54,7 +54,11 @@ static int select_sim_slot(struct mbim_data *mbim_priv) {
     g_autoptr(MbimMessage) current_slot_response =
         mbim_device_command_sync(mbim_priv->device, mbim_priv->context, current_slot_request, &error);
     if (!current_slot_response) {
-        fprintf(stderr, "error: device didn't respond: %s\n", error->message);
+        if (error->code == MBIM_STATUS_ERROR_NO_DEVICE_SUPPORT && mbim_priv->uim_slot == 0) {
+            return 0;
+        }
+
+        fprintf(stderr, "error: unable to query slot mapping: %s\n", error->message);
         return -1;
     }
 
@@ -85,7 +89,7 @@ static int select_sim_slot(struct mbim_data *mbim_priv) {
     g_autoptr(MbimMessage) update_slot_response =
         mbim_device_command_sync(mbim_priv->device, mbim_priv->context, update_slot_request, &error);
     if (!update_slot_response) {
-        fprintf(stderr, "error: device didn't respond: %s\n", error->message);
+        fprintf(stderr, "error: unable to select sim slot: %s\n", error->message);
         return -1;
     }
 


### PR DESCRIPTION
Modems that only have one sim slot may respond with NO_DEVICE_SUPPORT when we try to request the sim slot mapping in preparation for sim selection. This is (arguably) correct behavior when we're trying to select a sim slot that isn't there, but when we want to access slot 0, we shouldn't complain about it.

So catch the situation where we receive the NO_DEVICE_SUPPORT error and consider the switch action successful if we're trying to access the first and only sim slot.

While we're here, slightly improve two error lines to better indicate what's going wrong.

Tested with EM7590 and EM9291 configured for only a single sim slot (`AT!CUSTOM="UIM2ENABLE",0`).