### PR TITLE
feat(euicc): return the ICCID in the result of load_bound_profile_package

### DIFF
--- a/euicc/es10b.c
+++ b/euicc/es10b.c
@@ -172,13 +172,14 @@ static int es10b_load_bound_profile_package_tx(struct euicc_ctx *ctx,
     result->seqNumber = 0;
     result->bppCommandId = ES10B_BPP_COMMAND_ID_UNDEFINED;
     result->errorReason = ES10B_ERROR_REASON_UNDEFINED;
+    result->iccid = NULL;
 
     if (es10x_command(ctx, &respbuf, &resplen, reqbuf, reqbuf_len) < 0) {
         goto err;
     }
 
     if (resplen > 0) {
-        struct euicc_derutil_node tmpnode, n_notificationMetadata, n_sequenceNumber, n_finalResult;
+        struct euicc_derutil_node tmpnode, n_notificationMetadata, n_sequenceNumber, n_iccid, n_finalResult;
 
         if (euicc_derutil_unpack_find_tag(&tmpnode, 0xBF37, respbuf, resplen) < 0) // ProfileInstallationResult
         {
@@ -211,6 +212,18 @@ static int es10b_load_bound_profile_package_tx(struct euicc_ctx *ctx,
                                           n_notificationMetadata.length)
             == 0) {
             result->seqNumber = euicc_derutil_convert_bin2long(n_sequenceNumber.value, n_sequenceNumber.length);
+        }
+
+        if (euicc_derutil_unpack_find_tag(&n_iccid, 0x5A, n_notificationMetadata.value, n_notificationMetadata.length)
+            == 0) {
+            result->iccid = malloc((n_iccid.length * 2) + 1);
+            if (result->iccid) {
+                if (euicc_hexutil_bin2gsmbcd(result->iccid, (n_iccid.length * 2) + 1, n_iccid.value, n_iccid.length)
+                    < 0) {
+                    free(result->iccid);
+                    result->iccid = NULL;
+                }
+            }
         }
 
         switch (n_finalResult.tag) {

--- a/euicc/es10b.h
+++ b/euicc/es10b.h
@@ -59,6 +59,7 @@ enum es10b_cancel_session_reason {
 
 struct es10b_load_bound_profile_package_result {
     unsigned long seqNumber;
+    char *iccid;
     enum es10b_bpp_command_id bppCommandId;
     enum es10b_error_reason errorReason;
 };

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -60,6 +60,7 @@ static cJSON *build_download_result_json(const struct es10b_load_bound_profile_p
         return NULL;
     }
     cJSON_AddNumberToObject(jdata, "seqNumber", (double)result->seqNumber);
+    cJSON_AddStringOrNullToObject(jdata, "iccid", result->iccid);
     cJSON_AddStringToObject(jdata, "bppCommandId", euicc_bppcommandid2str(result->bppCommandId));
     cJSON_AddStringToObject(jdata, "errorReason", euicc_errorreason2str(result->errorReason));
     return jdata;


### PR DESCRIPTION
i found it helpful for the ICCID to be readily accessible at the end of a successful transaction, for tying it together with the incoming activation code and doing an automatic "change nickname" operation.

It feels like `struct es10b_notification_metadata_list` should be split to `struct es10b_notification_metadata` and then that added as a member of `struct es10b_load_bound_profile_package_result` but it would be a bit of a backwards compatibility for `seqNumber` to move, so settled on joining in with extracting the metadata out.