### PR TITLE
fix(euicc): Initialise es8+ metadata profileClass to Operational

### DIFF
--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -43,7 +43,7 @@ int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Me
     n_iter.self.ptr = n_metadata.value;
     n_iter.self.length = 0;
 
-    p->profileClass = ES10C_PROFILE_CLASS_NULL;
+    p->profileClass = ES10C_PROFILE_CLASS_OPERATIONAL;
     p->iconType = ES10C_ICON_TYPE_NULL;
 
     while (euicc_derutil_unpack_next(&n_iter, &n_iter, n_metadata.value, n_metadata.length) == 0) {


### PR DESCRIPTION
The ASN.1 for StoreMetadataRequest (BF25) defines profileClass as having a default value of "operational" [1]. Therefore, when the SM-DP+ omits this value from the response, "null" is an incorrect interpretation.

This behaviour was observed from consumer.e-sim.global. The eUICC correctly stores the profile class as operational.

Note this does not apply to ES10c ProfileInfo (E3) [2], so no corresponding change has been made to `es10c_get_profiles_info`.

[1] SGP.22 v3.1, page 293:

```asn1
StoreMetadataRequest ::= [37] SEQUENCE { -- Tag 'BF25'
  -- <snip>
  profileClass [21] ProfileClass DEFAULT operational, -- Tag '95'
  -- <snip>
}
```

[2] SGP.22 v3.1, page 345:

```asn1
ProfileInfo ::= [PRIVATE 3] SEQUENCE { -- Tag 'E3'
  -- <snip>
  profileClass [21] ProfileClass OPTIONAL, -- Tag '95'
  -- <snip>
}
```


edit: I noticed the project says it is targetting SGP.22 v2.2.2, same argument applies but the citations are page 163 and 196.