### PR TITLE
libeuicc: Implement AR-DO (tag 0xBF76) parsing in es8p metadata

### DIFF
--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -9,6 +9,116 @@
 #include <string.h>
 #include <unistd.h>
 
+static void es8p_metadata_access_rules_free(struct es8p_metadata_access_rule **access_rules) {
+    struct es8p_metadata_access_rule *rule = *access_rules;
+
+    while (rule) {
+        struct es8p_metadata_access_rule *next = rule->next;
+        free(rule->certificateHash);
+        free(rule->packageName);
+        free(rule);
+        rule = next;
+    }
+
+    *access_rules = NULL;
+}
+
+static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **access_rules, const uint8_t *buffer,
+                                            uint32_t buffer_len) {
+    struct euicc_derutil_node n_entry;
+    struct es8p_metadata_access_rule *last = NULL;
+    struct es8p_metadata_access_rule *rule = NULL;
+
+    *access_rules = NULL;
+
+    memset(&n_entry, 0, sizeof(n_entry));
+    n_entry.self.ptr = buffer;
+    n_entry.self.length = 0;
+
+    while (euicc_derutil_unpack_next(&n_entry, &n_entry, buffer, buffer_len) == 0) {
+        struct euicc_derutil_node n_e2_child;
+        struct euicc_derutil_node n_e1_child;
+        int found_e1 = 0;
+
+        if (n_entry.tag != 0xE2) {
+            continue;
+        }
+
+        rule = calloc(1, sizeof(*rule));
+        if (!rule) {
+            goto err;
+        }
+
+        memset(&n_e2_child, 0, sizeof(n_e2_child));
+        n_e2_child.self.ptr = n_entry.value;
+        n_e2_child.self.length = 0;
+
+        while (euicc_derutil_unpack_next(&n_e2_child, &n_e2_child, n_entry.value, n_entry.length) == 0) {
+            if (n_e2_child.tag != 0xE1) {
+                continue;
+            }
+
+            found_e1 = 1;
+
+            memset(&n_e1_child, 0, sizeof(n_e1_child));
+            n_e1_child.self.ptr = n_e2_child.value;
+            n_e1_child.self.length = 0;
+
+            while (euicc_derutil_unpack_next(&n_e1_child, &n_e1_child, n_e2_child.value, n_e2_child.length) == 0) {
+                switch (n_e1_child.tag) {
+                case 0xC1:
+                    rule->certificateHash = malloc((n_e1_child.length * 2) + 1);
+                    if (!rule->certificateHash) {
+                        goto err;
+                    }
+
+                    if (euicc_hexutil_bin2hex(rule->certificateHash, (n_e1_child.length * 2) + 1, n_e1_child.value,
+                                              n_e1_child.length)
+                        < 0) {
+                        goto err;
+                    }
+                    break;
+                case 0xCA:
+                    rule->packageName = malloc(n_e1_child.length + 1);
+                    if (!rule->packageName) {
+                        goto err;
+                    }
+
+                    memcpy(rule->packageName, n_e1_child.value, n_e1_child.length);
+                    rule->packageName[n_e1_child.length] = '\0';
+                    break;
+                }
+            }
+        }
+
+        if (!found_e1 || !rule->certificateHash) {
+            free(rule->certificateHash);
+            free(rule->packageName);
+            free(rule);
+            continue;
+        }
+
+        if (!*access_rules) {
+            *access_rules = rule;
+        } else {
+            last->next = rule;
+        }
+        last = rule;
+        rule = NULL;
+    }
+
+    return 0;
+
+err:
+    if (rule) {
+        free(rule->certificateHash);
+        free(rule->packageName);
+        free(rule);
+    }
+    es8p_metadata_access_rules_free(access_rules);
+    return -1;
+}
+
 int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Metadata) {
     int ret;
     uint8_t *metadata = NULL;
@@ -97,6 +207,11 @@ int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Me
                 break;
             }
             break;
+        case 0xBF76:
+            if (es8p_metadata_parse_access_rules(&p->accessRules, n_iter.value, n_iter.length) < 0) {
+                goto err;
+            }
+            break;
         case 0xB6:
         case 0xB7:
         case 0x99:
@@ -111,10 +226,7 @@ int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Me
 
 err:
     ret = -1;
-    free(*stru_metadata);
-    *stru_metadata = NULL;
-    free(p);
-    p = NULL;
+    es8p_metadata_free(&p);
 exit:
     free(metadata);
     metadata = NULL;
@@ -132,6 +244,7 @@ void es8p_metadata_free(struct es8p_metadata **stru_metadata) {
     free(p->serviceProviderName);
     free(p->profileName);
     free(p->icon);
+    es8p_metadata_access_rules_free(&p->accessRules);
     free(p);
 
     *stru_metadata = NULL;

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -60,9 +60,13 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
                                          n_ref_ar_do_entry.length)
                == 0) {
             if (n_ref_ar_do_child.tag == 0xE1) {
-                n_ref_do = n_ref_ar_do_child;
-                found_ref_do = 1;
-                break;
+                if (found_ref_do) {
+                    // We can't have multiple REF-DO's per REF-AR-DO
+                    goto err;
+                } else {
+                    n_ref_do = n_ref_ar_do_child;
+                    found_ref_do = 1;
+                }
             }
         }
 
@@ -80,6 +84,11 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
         while (euicc_derutil_unpack_next(&n_ref_do_child, &n_ref_do_child, n_ref_do.value, n_ref_do.length) == 0) {
             switch (n_ref_do_child.tag) {
             case 0xC1:
+                // There can only be one 0xC1 (cert hash) per REF-DO
+                if (rule->certificateHash) {
+                    goto err;
+                }
+
                 rule->certificateHash = malloc((n_ref_do_child.length * 2) + 1);
                 if (!rule->certificateHash) {
                     goto err;
@@ -92,6 +101,11 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
                 }
                 break;
             case 0xCA:
+                // There can only be one 0xCA (package name)
+                if (rule->packageName) {
+                    goto err;
+                }
+
                 rule->packageName = malloc(n_ref_do_child.length + 1);
                 if (!rule->packageName) {
                     goto err;

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -25,21 +25,20 @@ static void es8p_metadata_access_rules_free(struct es8p_metadata_access_rule **a
 
 static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **access_rules, const uint8_t *buffer,
                                             uint32_t buffer_len) {
-    struct euicc_derutil_node n_ref_ar_do_entry;
+    struct euicc_derutil_node n_ref_ar_do_entry = {0};
     struct es8p_metadata_access_rule *last = NULL;
     struct es8p_metadata_access_rule *rule = NULL;
 
     *access_rules = NULL;
 
-    memset(&n_ref_ar_do_entry, 0, sizeof(n_ref_ar_do_entry));
     n_ref_ar_do_entry.self.ptr = buffer;
     n_ref_ar_do_entry.self.length = 0;
 
     // Each 0xBF76 tag may contain multiple REF-AR-DO (0xE2) entries
     while (euicc_derutil_unpack_next(&n_ref_ar_do_entry, &n_ref_ar_do_entry, buffer, buffer_len) == 0) {
-        struct euicc_derutil_node n_ref_ar_do_child;
-        struct euicc_derutil_node n_ref_do_child;
-        struct euicc_derutil_node n_ref_do;
+        struct euicc_derutil_node n_ref_ar_do_child = {0};
+        struct euicc_derutil_node n_ref_do_child = {0};
+        struct euicc_derutil_node n_ref_do = {0};
         int found_ref_do = 0;
 
         if (n_ref_ar_do_entry.tag != 0xE2) {
@@ -51,7 +50,6 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
             goto err;
         }
 
-        memset(&n_ref_ar_do_child, 0, sizeof(n_ref_ar_do_child));
         n_ref_ar_do_child.self.ptr = n_ref_ar_do_entry.value;
         n_ref_ar_do_child.self.length = 0;
 
@@ -75,7 +73,6 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
             goto err;
         }
 
-        memset(&n_ref_do_child, 0, sizeof(n_ref_do_child));
         n_ref_do_child.self.ptr = n_ref_do.value;
         n_ref_do_child.self.length = 0;
 

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -226,6 +226,8 @@ int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Me
 
 err:
     ret = -1;
+    free(*stru_metadata);
+    *stru_metadata = NULL;
     es8p_metadata_free(&p);
 exit:
     free(metadata);

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -103,11 +103,9 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
             }
         }
 
+        // Each REF-DO child must at least contain a cert hash
         if (!rule->certificateHash) {
-            free(rule->certificateHash);
-            free(rule->packageName);
-            free(rule);
-            continue;
+            goto err;
         }
 
         if (!*access_rules) {

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -25,23 +25,23 @@ static void es8p_metadata_access_rules_free(struct es8p_metadata_access_rule **a
 
 static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **access_rules, const uint8_t *buffer,
                                             uint32_t buffer_len) {
-    struct euicc_derutil_node n_entry;
+    struct euicc_derutil_node n_ref_ar_do_entry;
     struct es8p_metadata_access_rule *last = NULL;
     struct es8p_metadata_access_rule *rule = NULL;
 
     *access_rules = NULL;
 
-    memset(&n_entry, 0, sizeof(n_entry));
-    n_entry.self.ptr = buffer;
-    n_entry.self.length = 0;
+    memset(&n_ref_ar_do_entry, 0, sizeof(n_ref_ar_do_entry));
+    n_ref_ar_do_entry.self.ptr = buffer;
+    n_ref_ar_do_entry.self.length = 0;
 
-    while (euicc_derutil_unpack_next(&n_entry, &n_entry, buffer, buffer_len) == 0) {
-        struct euicc_derutil_node n_e2_child;
-        struct euicc_derutil_node n_e1_child;
-        struct euicc_derutil_node n_e1;
-        int found_e1 = 0;
+    while (euicc_derutil_unpack_next(&n_ref_ar_do_entry, &n_ref_ar_do_entry, buffer, buffer_len) == 0) {
+        struct euicc_derutil_node n_ref_ar_do_child;
+        struct euicc_derutil_node n_ref_do_child;
+        struct euicc_derutil_node n_ref_do;
+        int found_ref_do = 0;
 
-        if (n_entry.tag != 0xE2) {
+        if (n_ref_ar_do_entry.tag != 0xE2) {
             continue;
         }
 
@@ -50,51 +50,50 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
             goto err;
         }
 
-        memset(&n_e2_child, 0, sizeof(n_e2_child));
-        n_e2_child.self.ptr = n_entry.value;
-        n_e2_child.self.length = 0;
+        memset(&n_ref_ar_do_child, 0, sizeof(n_ref_ar_do_child));
+        n_ref_ar_do_child.self.ptr = n_ref_ar_do_entry.value;
+        n_ref_ar_do_child.self.length = 0;
 
-        while (euicc_derutil_unpack_next(&n_e2_child, &n_e2_child, n_entry.value, n_entry.length) == 0) {
-            if (n_e2_child.tag == 0xE1) {
-                n_e1 = n_e2_child;
-                found_e1 = 1;
+        while (euicc_derutil_unpack_next(&n_ref_ar_do_child, &n_ref_ar_do_child, n_ref_ar_do_entry.value,
+                                         n_ref_ar_do_entry.length)
+               == 0) {
+            if (n_ref_ar_do_child.tag == 0xE1) {
+                n_ref_do = n_ref_ar_do_child;
+                found_ref_do = 1;
                 break;
             }
         }
 
-        if (!found_e1) {
-            free(rule->certificateHash);
-            free(rule->packageName);
-            free(rule);
-            continue;
+        if (!found_ref_do) {
+            goto err;
         }
 
-        memset(&n_e1_child, 0, sizeof(n_e1_child));
-        n_e1_child.self.ptr = n_e1.value;
-        n_e1_child.self.length = 0;
+        memset(&n_ref_do_child, 0, sizeof(n_ref_do_child));
+        n_ref_do_child.self.ptr = n_ref_do.value;
+        n_ref_do_child.self.length = 0;
 
-        while (euicc_derutil_unpack_next(&n_e1_child, &n_e1_child, n_e1.value, n_e1.length) == 0) {
-            switch (n_e1_child.tag) {
+        while (euicc_derutil_unpack_next(&n_ref_do_child, &n_ref_do_child, n_ref_do.value, n_ref_do.length) == 0) {
+            switch (n_ref_do_child.tag) {
             case 0xC1:
-                rule->certificateHash = malloc((n_e1_child.length * 2) + 1);
+                rule->certificateHash = malloc((n_ref_do_child.length * 2) + 1);
                 if (!rule->certificateHash) {
                     goto err;
                 }
 
-                if (euicc_hexutil_bin2hex(rule->certificateHash, (n_e1_child.length * 2) + 1, n_e1_child.value,
-                                          n_e1_child.length)
+                if (euicc_hexutil_bin2hex(rule->certificateHash, (n_ref_do_child.length * 2) + 1, n_ref_do_child.value,
+                                          n_ref_do_child.length)
                     < 0) {
                     goto err;
                 }
                 break;
             case 0xCA:
-                rule->packageName = malloc(n_e1_child.length + 1);
+                rule->packageName = malloc(n_ref_do_child.length + 1);
                 if (!rule->packageName) {
                     goto err;
                 }
 
-                memcpy(rule->packageName, n_e1_child.value, n_e1_child.length);
-                rule->packageName[n_e1_child.length] = '\0';
+                memcpy(rule->packageName, n_ref_do_child.value, n_ref_do_child.length);
+                rule->packageName[n_ref_do_child.length] = '\0';
                 break;
             }
         }

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -35,6 +35,7 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
     n_ref_ar_do_entry.self.ptr = buffer;
     n_ref_ar_do_entry.self.length = 0;
 
+    // Each 0xBF76 tag may contain multiple REF-AR-DO (0xE2) entries
     while (euicc_derutil_unpack_next(&n_ref_ar_do_entry, &n_ref_ar_do_entry, buffer, buffer_len) == 0) {
         struct euicc_derutil_node n_ref_ar_do_child;
         struct euicc_derutil_node n_ref_do_child;
@@ -54,6 +55,7 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
         n_ref_ar_do_child.self.ptr = n_ref_ar_do_entry.value;
         n_ref_ar_do_child.self.length = 0;
 
+        // Each REF-AR-DO must contain EXACTLY 1 REF-DO (0xE1)
         while (euicc_derutil_unpack_next(&n_ref_ar_do_child, &n_ref_ar_do_child, n_ref_ar_do_entry.value,
                                          n_ref_ar_do_entry.length)
                == 0) {
@@ -64,6 +66,7 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
             }
         }
 
+        // If we don't find REF-DO, abort
         if (!found_ref_do) {
             goto err;
         }
@@ -72,6 +75,8 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
         n_ref_do_child.self.ptr = n_ref_do.value;
         n_ref_do_child.self.length = 0;
 
+        // Now we have REF-DO, each MUST contain a 0xC1 (cert hash)
+        // Optionally, a 0xCA (package name)
         while (euicc_derutil_unpack_next(&n_ref_do_child, &n_ref_do_child, n_ref_do.value, n_ref_do.length) == 0) {
             switch (n_ref_do_child.tag) {
             case 0xC1:
@@ -215,6 +220,7 @@ int es8p_metadata_parse(struct es8p_metadata **stru_metadata, const char *b64_Me
             }
             break;
         case 0xBF76:
+            // Android's extension, AR-DO in profile metadata
             if (es8p_metadata_parse_access_rules(&p->accessRules, n_iter.value, n_iter.length) < 0) {
                 goto err;
             }

--- a/euicc/es8p.c
+++ b/euicc/es8p.c
@@ -38,6 +38,7 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
     while (euicc_derutil_unpack_next(&n_entry, &n_entry, buffer, buffer_len) == 0) {
         struct euicc_derutil_node n_e2_child;
         struct euicc_derutil_node n_e1_child;
+        struct euicc_derutil_node n_e1;
         int found_e1 = 0;
 
         if (n_entry.tag != 0xE2) {
@@ -54,44 +55,51 @@ static int es8p_metadata_parse_access_rules(struct es8p_metadata_access_rule **a
         n_e2_child.self.length = 0;
 
         while (euicc_derutil_unpack_next(&n_e2_child, &n_e2_child, n_entry.value, n_entry.length) == 0) {
-            if (n_e2_child.tag != 0xE1) {
-                continue;
-            }
-
-            found_e1 = 1;
-
-            memset(&n_e1_child, 0, sizeof(n_e1_child));
-            n_e1_child.self.ptr = n_e2_child.value;
-            n_e1_child.self.length = 0;
-
-            while (euicc_derutil_unpack_next(&n_e1_child, &n_e1_child, n_e2_child.value, n_e2_child.length) == 0) {
-                switch (n_e1_child.tag) {
-                case 0xC1:
-                    rule->certificateHash = malloc((n_e1_child.length * 2) + 1);
-                    if (!rule->certificateHash) {
-                        goto err;
-                    }
-
-                    if (euicc_hexutil_bin2hex(rule->certificateHash, (n_e1_child.length * 2) + 1, n_e1_child.value,
-                                              n_e1_child.length)
-                        < 0) {
-                        goto err;
-                    }
-                    break;
-                case 0xCA:
-                    rule->packageName = malloc(n_e1_child.length + 1);
-                    if (!rule->packageName) {
-                        goto err;
-                    }
-
-                    memcpy(rule->packageName, n_e1_child.value, n_e1_child.length);
-                    rule->packageName[n_e1_child.length] = '\0';
-                    break;
-                }
+            if (n_e2_child.tag == 0xE1) {
+                n_e1 = n_e2_child;
+                found_e1 = 1;
+                break;
             }
         }
 
-        if (!found_e1 || !rule->certificateHash) {
+        if (!found_e1) {
+            free(rule->certificateHash);
+            free(rule->packageName);
+            free(rule);
+            continue;
+        }
+
+        memset(&n_e1_child, 0, sizeof(n_e1_child));
+        n_e1_child.self.ptr = n_e1.value;
+        n_e1_child.self.length = 0;
+
+        while (euicc_derutil_unpack_next(&n_e1_child, &n_e1_child, n_e1.value, n_e1.length) == 0) {
+            switch (n_e1_child.tag) {
+            case 0xC1:
+                rule->certificateHash = malloc((n_e1_child.length * 2) + 1);
+                if (!rule->certificateHash) {
+                    goto err;
+                }
+
+                if (euicc_hexutil_bin2hex(rule->certificateHash, (n_e1_child.length * 2) + 1, n_e1_child.value,
+                                          n_e1_child.length)
+                    < 0) {
+                    goto err;
+                }
+                break;
+            case 0xCA:
+                rule->packageName = malloc(n_e1_child.length + 1);
+                if (!rule->packageName) {
+                    goto err;
+                }
+
+                memcpy(rule->packageName, n_e1_child.value, n_e1_child.length);
+                rule->packageName[n_e1_child.length] = '\0';
+                break;
+            }
+        }
+
+        if (!rule->certificateHash) {
             free(rule->certificateHash);
             free(rule->packageName);
             free(rule);

--- a/euicc/es8p.h
+++ b/euicc/es8p.h
@@ -23,6 +23,13 @@ struct es8p_metadata {
         char *dpOid;
     } dpProprietaryData;
     char **profilePolicyRules;
+    struct es8p_metadata_access_rule *accessRules;
+};
+
+struct es8p_metadata_access_rule {
+    char *certificateHash;
+    char *packageName;
+    struct es8p_metadata_access_rule *next;
 };
 
 int es8p_metadata_parse(struct es8p_metadata **metadata, const char *b64_Metadata);

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -108,6 +108,7 @@ static int applet_main(int argc, char **argv) {
     struct es10b_load_bound_profile_package_result download_result = {0};
 
     cJSON *jmetadata = NULL;
+    cJSON *jaccessRules = NULL;
     _cleanup_(es8p_metadata_free) struct es8p_metadata *profile_metadata = NULL;
 
     while ((opt = getopt(argc, argv, opt_string)) != -1) {
@@ -264,13 +265,10 @@ static int applet_main(int argc, char **argv) {
         cJSON_AddStringOrNullToObject(jmetadata, "icon", profile_metadata->icon);
         cJSON_AddStringOrNullToObject(jmetadata, "profileClass",
                                       euicc_profileclass2str(profile_metadata->profileClass));
-        {
-            cJSON *jrules = build_access_rules_json(profile_metadata->accessRules);
-            if (jrules) {
-                cJSON_AddItemToObject(jmetadata, "accessRules", jrules);
-            } else {
-                cJSON_AddNullToObject(jmetadata, "accessRules");
-            }
+        jaccessRules = build_access_rules_json(profile_metadata->accessRules);
+        if (jaccessRules) {
+            cJSON_AddItemToObject(jmetadata, "accessRules", jaccessRules);
+            jaccessRules = NULL;
         }
 
         jprint_progress_obj("es8p_metadata_parse", jmetadata);

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -265,10 +265,12 @@ static int applet_main(int argc, char **argv) {
         cJSON_AddStringOrNullToObject(jmetadata, "icon", profile_metadata->icon);
         cJSON_AddStringOrNullToObject(jmetadata, "profileClass",
                                       euicc_profileclass2str(profile_metadata->profileClass));
-        jaccessRules = build_access_rules_json(profile_metadata->accessRules);
-        if (jaccessRules) {
-            cJSON_AddItemToObject(jmetadata, "accessRules", jaccessRules);
-            jaccessRules = NULL;
+        if (profile_metadata->accessRules) {
+            jaccessRules = build_access_rules_json(profile_metadata->accessRules);
+            if (jaccessRules) {
+                cJSON_AddItemToObject(jmetadata, "accessRules", jaccessRules);
+                jaccessRules = NULL;
+            }
         }
 
         jprint_progress_obj("es8p_metadata_parse", jmetadata);

--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -65,6 +65,31 @@ static cJSON *build_download_result_json(const struct es10b_load_bound_profile_p
     return jdata;
 }
 
+static cJSON *build_access_rules_json(const struct es8p_metadata_access_rule *rules) {
+    cJSON *jrules = cJSON_CreateArray();
+    const struct es8p_metadata_access_rule *rule = rules;
+
+    if (!jrules) {
+        return NULL;
+    }
+
+    while (rule) {
+        cJSON *jrule = cJSON_CreateObject();
+        if (!jrule) {
+            cJSON_Delete(jrules);
+            return NULL;
+        }
+
+        cJSON_AddStringOrNullToObject(jrule, "certificateHash", rule->certificateHash);
+        cJSON_AddStringOrNullToObject(jrule, "packageName", rule->packageName);
+        cJSON_AddItemToArray(jrules, jrule);
+
+        rule = rule->next;
+    }
+
+    return jrules;
+}
+
 static int applet_main(int argc, char **argv) {
     int fret;
     const char *error_function_name = NULL;
@@ -239,6 +264,14 @@ static int applet_main(int argc, char **argv) {
         cJSON_AddStringOrNullToObject(jmetadata, "icon", profile_metadata->icon);
         cJSON_AddStringOrNullToObject(jmetadata, "profileClass",
                                       euicc_profileclass2str(profile_metadata->profileClass));
+        {
+            cJSON *jrules = build_access_rules_json(profile_metadata->accessRules);
+            if (jrules) {
+                cJSON_AddItemToObject(jmetadata, "accessRules", jrules);
+            } else {
+                cJSON_AddNullToObject(jmetadata, "accessRules");
+            }
+        }
 
         jprint_progress_obj("es8p_metadata_parse", jmetadata);
 


### PR DESCRIPTION
This is added by some profiles targetting usage on Android with EuiccService API. EuiccService will return these access rules to the system, which decides whether to allow download to proceed based on the certificate hash, i.e. if the requesting app does not match the hash specified in the profile's access rules, download process is aborted.