### PR TITLE
fix(win32): export all symbols to fix 32 bit pseudo relocation out of range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ else()
     set(DL_LIBRARY dl)
 endif()
 
+# Only useful on Windows, and will lead to invalid arguments on ld.gold.
+if(WIN32)
+    add_link_options("LINKER:--export-all-symbols")
+endif()
+
 if (USE_SYSTEM_DEPS)
     find_package(cJSON REQUIRED)
 elseif (NOT NO_NETWORK)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -38,11 +38,6 @@ target_sources(
             euicc-driver-loader.h
 )
 
-# Only useful on Windows, and will lead to invalid arguments on ld.gold.
-if(WIN32)
-    target_link_options(euicc-driver-loader PRIVATE "LINKER:--export-all-symbols")
-endif()
-
 add_library(driver_apdu_stdio SHARED apdu/stdio.c)
 target_link_libraries(driver_apdu_stdio PRIVATE euicc euicc-drivers lpac-utils)
 set_target_properties(driver_apdu_stdio PROPERTIES PREFIX "")

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -17,8 +17,4 @@ struct euicc_driver {
     void (*fini)(void *interface);
 };
 
-#if defined(_WIN32)
-#    define DRIVER_INTERFACE __declspec(dllexport) const struct euicc_driver driver_if
-#else
-#    define DRIVER_INTERFACE const struct euicc_driver driver_if
-#endif
+#define DRIVER_INTERFACE const struct euicc_driver driver_if

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -4,8 +4,6 @@ target_link_libraries(lpac-utils PRIVATE ${CJSON_LIBRARY} euicc)
 target_compile_options(lpac-utils PRIVATE -Wall -Wextra)
 
 if(WIN32)
-    # Only useful on Windows, and will lead to invalid arguments on ld.gold.
-    target_link_options(lpac-utils PRIVATE "LINKER:--export-all-symbols")
     # FIXME: Glibc since 2.17 have move clock_* from librt to libc so
     #        single-thread program can use these functions without the
     #        overheads associated with multi-thread support.


### PR DESCRIPTION
> Mingw-w64 runtime failure:
> 32 bit pseudo relocation at 00007FF6DD041527 out of range, targeting 00007FFBA8B94B26, yielding the value 00000004CBB535FB.

Mark all interface functions for all driver is a bit complex, since all internal functions should be marked as static, just follow *nix behavior to export all symbols is the simplest way.

resolve #424