### PR TITLE
fix(win32): use dllexport/dllimport to avoid generate wrong 32 bits pesudo relocations

### DIFF
--- a/cjson-ext/cjson-ext/cJSON_ex.c
+++ b/cjson-ext/cjson-ext/cJSON_ex.c
@@ -1,6 +1,7 @@
 #include "cJSON_ex.h"
 
-inline cJSON *cJSON_AddStringOrNullToObject(cJSON *const object, const char *const name, const char *const string) {
+CJSON_EXT_API cJSON *cJSON_AddStringOrNullToObject(cJSON *const object, const char *const name,
+                                                   const char *const string) {
     if (string) {
         return cJSON_AddStringToObject(object, name, string);
     } else {

--- a/cjson-ext/cjson-ext/cJSON_ex.h
+++ b/cjson-ext/cjson-ext/cJSON_ex.h
@@ -2,4 +2,11 @@
 
 #include <cjson/cJSON.h>
 
-cJSON *cJSON_AddStringOrNullToObject(cJSON *const object, const char *const name, const char *const string);
+#if defined(_WIN32)
+#    define CJSON_EXT_API __declspec(dllexport)
+#else
+#    define CJSON_EXT_API
+#endif
+
+CJSON_EXT_API cJSON *cJSON_AddStringOrNullToObject(cJSON *const object, const char *const name,
+                                                   const char *const string);

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
 )
 
 add_library(euicc-driver-loader SHARED)
+target_compile_definitions(euicc-driver-loader PRIVATE DRIVER_EXPORTS)
 target_link_libraries(euicc-driver-loader PRIVATE euicc euicc-drivers ${DL_LIBRARY} ${CJSON_LIBRARY} lpac-utils)
 target_sources(
     euicc-driver-loader
@@ -37,11 +38,6 @@ target_sources(
         FILES
             euicc-driver-loader.h
 )
-
-# Only useful on Windows, and will lead to invalid arguments on ld.gold.
-if(WIN32)
-    target_link_options(euicc-driver-loader PRIVATE "LINKER:--export-all-symbols")
-endif()
 
 add_library(driver_apdu_stdio SHARED apdu/stdio.c)
 target_link_libraries(driver_apdu_stdio PRIVATE euicc euicc-drivers lpac-utils)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -24,6 +24,10 @@ target_sources(
 add_library(euicc-driver-loader SHARED)
 target_compile_definitions(euicc-driver-loader PRIVATE DRIVER_EXPORTS)
 target_link_libraries(euicc-driver-loader PRIVATE euicc euicc-drivers ${DL_LIBRARY} ${CJSON_LIBRARY} lpac-utils)
+if(WIN32)
+    # To expose all missing dllimport/dllexport
+    target_link_options(euicc-driver-loader PRIVATE "LINKER:--disable-auto-import")
+endif()
 target_sources(
     euicc-driver-loader
     PRIVATE

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -4,6 +4,16 @@
 #    undef interface
 #endif
 
+#if defined(_WIN32)
+#    ifdef DRIVER_EXPORTS
+#        define DRIVER_API __declspec(dllexport)
+#    else
+#        define DRIVER_API __declspec(dllimport)
+#    endif
+#else
+#    define DRIVER_API
+#endif
+
 enum euicc_driver_type {
     DRIVER_APDU,
     DRIVER_HTTP,

--- a/driver/euicc-driver-loader.c
+++ b/driver/euicc-driver-loader.c
@@ -1,6 +1,7 @@
 // Needed by dlinfo(3).
 #define _GNU_SOURCE
-#include "driver.h"
+
+#include "euicc-driver-loader.h"
 
 #include <lpac/list.h>
 #include <lpac/utils.h>
@@ -38,8 +39,8 @@
 static const struct euicc_driver *_driver_apdu = NULL;
 static const struct euicc_driver *_driver_http = NULL;
 
-struct euicc_apdu_interface euicc_driver_interface_apdu;
-struct euicc_http_interface euicc_driver_interface_http;
+DRIVER_API struct euicc_apdu_interface euicc_driver_interface_apdu;
+DRIVER_API struct euicc_http_interface euicc_driver_interface_http;
 
 struct euicc_drivers_list {
     const struct euicc_driver *driver;
@@ -350,7 +351,7 @@ static inline const struct euicc_driver *find_driver(const enum euicc_driver_typ
     }
 }
 
-int euicc_driver_list(int argc, char **argv) {
+DRIVER_API int euicc_driver_list(int argc, char **argv) {
     if (!init_driver_list()) {
         fputs("Driver list initialization failed.\n", stderr);
         return -1;
@@ -383,7 +384,7 @@ int euicc_driver_list(int argc, char **argv) {
     return 0;
 }
 
-int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name) {
+DRIVER_API int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name) {
     _driver_apdu = find_driver(DRIVER_APDU, apdu_driver_name);
     if (_driver_apdu == NULL) {
         fprintf(stderr, "No APDU driver found\n");
@@ -409,7 +410,7 @@ int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name
     return 0;
 }
 
-void euicc_driver_fini() {
+DRIVER_API void euicc_driver_fini() {
     if (_driver_apdu != NULL && _driver_apdu->fini != NULL) {
         _driver_apdu->fini(&euicc_driver_interface_apdu);
     }
@@ -418,7 +419,7 @@ void euicc_driver_fini() {
     }
 }
 
-int euicc_driver_main_apdu(const int argc, char **argv) {
+DRIVER_API int euicc_driver_main_apdu(const int argc, char **argv) {
     if (_driver_apdu == NULL) {
         fprintf(stderr, "No APDU driver found\n");
         return -1;
@@ -430,7 +431,7 @@ int euicc_driver_main_apdu(const int argc, char **argv) {
     return _driver_apdu->main(&euicc_driver_interface_apdu, argc, argv);
 }
 
-int euicc_driver_main_http(const int argc, char **argv) {
+DRIVER_API int euicc_driver_main_http(const int argc, char **argv) {
     if (_driver_http == NULL) {
         fprintf(stderr, "No HTTP driver found\n");
         return -1;

--- a/driver/euicc-driver-loader.h
+++ b/driver/euicc-driver-loader.h
@@ -1,16 +1,17 @@
 #pragma once
 
+#include "driver.h"
 #include <euicc/interface.h>
 
 #include <inttypes.h>
 #include <stddef.h>
 
-extern struct euicc_apdu_interface euicc_driver_interface_apdu;
-extern struct euicc_http_interface euicc_driver_interface_http;
+extern DRIVER_API struct euicc_apdu_interface euicc_driver_interface_apdu;
+extern DRIVER_API struct euicc_http_interface euicc_driver_interface_http;
 
-int euicc_driver_list(int argc, char **argv);
-int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name);
-void euicc_driver_fini(void);
+DRIVER_API int euicc_driver_list(int argc, char **argv);
+DRIVER_API int euicc_driver_init(const char *apdu_driver_name, const char *http_driver_name);
+DRIVER_API void euicc_driver_fini(void);
 
-extern int euicc_driver_main_apdu(int argc, char **argv);
-extern int euicc_driver_main_http(int argc, char **argv);
+DRIVER_API int euicc_driver_main_apdu(int argc, char **argv);
+DRIVER_API int euicc_driver_main_http(int argc, char **argv);

--- a/euicc/CMakeLists.txt
+++ b/euicc/CMakeLists.txt
@@ -2,6 +2,7 @@ option(LIBEUICC_REDUCED_STDLIB_CALL "Reduce standard library calling" OFF)
 
 if(LPAC_DYNAMIC_LIBEUICC)
     add_library(euicc SHARED)
+    target_compile_definitions(euicc PRIVATE LIBEUICC_EXPORTS)
 else()
     add_library(euicc STATIC)
 endif()
@@ -55,6 +56,7 @@ target_sources(
             es10a.h
             es10c.h
             euicc.h
+            euicc_export.h
             hexutil.h
             sha256.h
 
@@ -68,10 +70,6 @@ set_target_properties(euicc PROPERTIES
         C_EXTENSIONS ON
 )
 if(LPAC_DYNAMIC_LIBEUICC)
-    # Only useful on Windows, and will lead to invalid arguments on ld.gold.
-    if(WIN32)
-        target_link_options(euicc PRIVATE "LINKER:--export-all-symbols")
-    endif()
     if (NOT STANDALONE_MODE)
         # Install a pkg-config file
         configure_file(libeuicc.pc.in libeuicc.pc @ONLY)

--- a/euicc/CMakeLists.txt
+++ b/euicc/CMakeLists.txt
@@ -70,6 +70,10 @@ set_target_properties(euicc PROPERTIES
         C_EXTENSIONS ON
 )
 if(LPAC_DYNAMIC_LIBEUICC)
+    if(WIN32)
+        # To expose all missing dllimport/dllexport
+        target_link_options(euicc PRIVATE "LINKER:--disable-auto-import")
+    endif()
     if (NOT STANDALONE_MODE)
         # Install a pkg-config file
         configure_file(libeuicc.pc.in libeuicc.pc @ONLY)

--- a/euicc/base64.h
+++ b/euicc/base64.h
@@ -1,6 +1,8 @@
 #pragma once
 
-int euicc_base64_decode_len(const char *bufcoded);
-int euicc_base64_decode(unsigned char *bufplain, const char *bufcoded);
-int euicc_base64_encode_len(int len);
-int euicc_base64_encode(char *encoded, const unsigned char *string, int len);
+#include "euicc_export.h"
+
+EUICC_API int euicc_base64_decode_len(const char *bufcoded);
+EUICC_API int euicc_base64_decode(unsigned char *bufplain, const char *bufcoded);
+EUICC_API int euicc_base64_encode_len(int len);
+EUICC_API int euicc_base64_encode(char *encoded, const unsigned char *string, int len);

--- a/euicc/derutil.h
+++ b/euicc/derutil.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include <inttypes.h>
 
@@ -18,20 +19,22 @@ struct euicc_derutil_node {
     } pack;
 };
 
-int euicc_derutil_unpack_first(struct euicc_derutil_node *result, const uint8_t *buffer, uint32_t buffer_len);
-int euicc_derutil_unpack_next(struct euicc_derutil_node *result, struct euicc_derutil_node *prev, const uint8_t *buffer,
-                              uint32_t buffer_len);
-int euicc_derutil_unpack_find_alias_tags(struct euicc_derutil_node *result, const uint16_t *tags, uint32_t tags_count,
-                                         const uint8_t *buffer, uint32_t buffer_len);
-int euicc_derutil_unpack_find_tag(struct euicc_derutil_node *result, uint16_t tag, const uint8_t *buffer,
-                                  uint32_t buffer_len);
+EUICC_API int euicc_derutil_unpack_first(struct euicc_derutil_node *result, const uint8_t *buffer, uint32_t buffer_len);
+EUICC_API int euicc_derutil_unpack_next(struct euicc_derutil_node *result, struct euicc_derutil_node *prev,
+                                        const uint8_t *buffer, uint32_t buffer_len);
+EUICC_API int euicc_derutil_unpack_find_alias_tags(struct euicc_derutil_node *result, const uint16_t *tags,
+                                                   uint32_t tags_count, const uint8_t *buffer, uint32_t buffer_len);
+EUICC_API int euicc_derutil_unpack_find_tag(struct euicc_derutil_node *result, uint16_t tag, const uint8_t *buffer,
+                                            uint32_t buffer_len);
 
-int euicc_derutil_pack(uint8_t *buffer, uint32_t *buffer_len, struct euicc_derutil_node *node);
-int euicc_derutil_pack_alloc(uint8_t **buffer, uint32_t *buffer_len, struct euicc_derutil_node *node);
+EUICC_API int euicc_derutil_pack(uint8_t *buffer, uint32_t *buffer_len, struct euicc_derutil_node *node);
+EUICC_API int euicc_derutil_pack_alloc(uint8_t **buffer, uint32_t *buffer_len, struct euicc_derutil_node *node);
 
-long euicc_derutil_convert_bin2long(const uint8_t *buffer, uint32_t buffer_len);
-int euicc_derutil_convert_long2bin(uint8_t *buffer, uint32_t *buffer_len, long value);
-int euicc_derutil_convert_bits2bin(uint8_t *buffer, uint32_t buffer_len, const uint32_t *bits, uint32_t bits_count);
-int euicc_derutil_convert_bits2bin_alloc(uint8_t **buffer, uint32_t *buffer_len, const uint32_t *bits,
-                                         uint32_t bits_count);
-int euicc_derutil_convert_bin2bits_str(const char ***output, const uint8_t *buffer, int buffer_len, const char **desc);
+EUICC_API long euicc_derutil_convert_bin2long(const uint8_t *buffer, uint32_t buffer_len);
+EUICC_API int euicc_derutil_convert_long2bin(uint8_t *buffer, uint32_t *buffer_len, long value);
+EUICC_API int euicc_derutil_convert_bits2bin(uint8_t *buffer, uint32_t buffer_len, const uint32_t *bits,
+                                             uint32_t bits_count);
+EUICC_API int euicc_derutil_convert_bits2bin_alloc(uint8_t **buffer, uint32_t *buffer_len, const uint32_t *bits,
+                                                   uint32_t bits_count);
+EUICC_API int euicc_derutil_convert_bin2bits_str(const char ***output, const uint8_t *buffer, int buffer_len,
+                                                 const char **desc);

--- a/euicc/es10a.h
+++ b/euicc/es10a.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "euicc.h"
 
@@ -7,7 +8,8 @@ struct es10a_euicc_configured_addresses {
     char *rootDsAddress;
 };
 
-int es10a_get_euicc_configured_addresses(struct euicc_ctx *ctx, struct es10a_euicc_configured_addresses *address);
-int es10a_set_default_dp_address(struct euicc_ctx *ctx, const char *smdp);
+EUICC_API int es10a_get_euicc_configured_addresses(struct euicc_ctx *ctx,
+                                                   struct es10a_euicc_configured_addresses *address);
+EUICC_API int es10a_set_default_dp_address(struct euicc_ctx *ctx, const char *smdp);
 
-void es10a_euicc_configured_addresses_free(struct es10a_euicc_configured_addresses *address);
+EUICC_API void es10a_euicc_configured_addresses_free(struct es10a_euicc_configured_addresses *address);

--- a/euicc/es10b.h
+++ b/euicc/es10b.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include <stdint.h>
 
@@ -123,35 +124,41 @@ struct es10b_operation_id {
     struct es10b_operation_id *next;
 };
 
-int es10b_prepare_download_r(struct euicc_ctx *ctx, char **b64_PrepareDownloadResponse,
-                             struct es10b_prepare_download_param *param,
-                             struct es10b_prepare_download_param_user *param_user);
-int es10b_load_bound_profile_package_r(struct euicc_ctx *ctx, struct es10b_load_bound_profile_package_result *result,
-                                       const char *b64_BoundProfilePackage);
-int es10b_get_euicc_challenge_r(struct euicc_ctx *ctx, char **b64_euiccChallenge);
-int es10b_get_euicc_info_r(struct euicc_ctx *ctx, char **b64_EUICCInfo1);
-int es10b_authenticate_server_r(struct euicc_ctx *ctx, uint8_t **transaction_id, uint32_t *transaction_id_len,
-                                char **b64_AuthenticateServerResponse, struct es10b_authenticate_server_param *param,
-                                struct es10b_authenticate_server_param_user *param_user);
-int es10b_cancel_session_r(struct euicc_ctx *ctx, char **b64_CancelSessionResponse,
-                           struct es10b_cancel_session_param *param);
+EUICC_API int es10b_prepare_download_r(struct euicc_ctx *ctx, char **b64_PrepareDownloadResponse,
+                                       struct es10b_prepare_download_param *param,
+                                       struct es10b_prepare_download_param_user *param_user);
+EUICC_API int es10b_load_bound_profile_package_r(struct euicc_ctx *ctx,
+                                                 struct es10b_load_bound_profile_package_result *result,
+                                                 const char *b64_BoundProfilePackage);
+EUICC_API int es10b_get_euicc_challenge_r(struct euicc_ctx *ctx, char **b64_euiccChallenge);
+EUICC_API int es10b_get_euicc_info_r(struct euicc_ctx *ctx, char **b64_EUICCInfo1);
+EUICC_API int es10b_authenticate_server_r(struct euicc_ctx *ctx, uint8_t **transaction_id, uint32_t *transaction_id_len,
+                                          char **b64_AuthenticateServerResponse,
+                                          struct es10b_authenticate_server_param *param,
+                                          struct es10b_authenticate_server_param_user *param_user);
+EUICC_API int es10b_cancel_session_r(struct euicc_ctx *ctx, char **b64_CancelSessionResponse,
+                                     struct es10b_cancel_session_param *param);
 
-void es10b_prepare_download_param_free(struct es10b_prepare_download_param *param);
-void es10b_authenticate_server_param_free(struct es10b_authenticate_server_param *param);
+EUICC_API void es10b_prepare_download_param_free(struct es10b_prepare_download_param *param);
+EUICC_API void es10b_authenticate_server_param_free(struct es10b_authenticate_server_param *param);
 
-int es10b_prepare_download(struct euicc_ctx *ctx, const char *confirmationCode);
-int es10b_load_bound_profile_package(struct euicc_ctx *ctx, struct es10b_load_bound_profile_package_result *result);
-int es10b_get_euicc_challenge_and_info(struct euicc_ctx *ctx);
-int es10b_authenticate_server(struct euicc_ctx *ctx, const char *matchingId, const char *imei);
-int es10b_cancel_session(struct euicc_ctx *ctx, enum es10b_cancel_session_reason reason);
+EUICC_API int es10b_prepare_download(struct euicc_ctx *ctx, const char *confirmationCode);
+EUICC_API int es10b_load_bound_profile_package(struct euicc_ctx *ctx,
+                                               struct es10b_load_bound_profile_package_result *result);
+EUICC_API int es10b_get_euicc_challenge_and_info(struct euicc_ctx *ctx);
+EUICC_API int es10b_authenticate_server(struct euicc_ctx *ctx, const char *matchingId, const char *imei);
+EUICC_API int es10b_cancel_session(struct euicc_ctx *ctx, enum es10b_cancel_session_reason reason);
 
-int es10b_list_notification(struct euicc_ctx *ctx, struct es10b_notification_metadata_list **notificationMetadataList);
-int es10b_retrieve_notifications_list(struct euicc_ctx *ctx, struct es10b_pending_notification *PendingNotification,
-                                      unsigned long seqNumber);
-int es10b_remove_notification_from_list(struct euicc_ctx *ctx, unsigned long seqNumber);
+EUICC_API int es10b_list_notification(struct euicc_ctx *ctx,
+                                      struct es10b_notification_metadata_list **notificationMetadataList);
+EUICC_API int es10b_retrieve_notifications_list(struct euicc_ctx *ctx,
+                                                struct es10b_pending_notification *PendingNotification,
+                                                unsigned long seqNumber);
+EUICC_API int es10b_remove_notification_from_list(struct euicc_ctx *ctx, unsigned long seqNumber);
 
-void es10b_notification_metadata_list_free_all(struct es10b_notification_metadata_list *notificationMetadataList);
-void es10b_pending_notification_free(struct es10b_pending_notification *PendingNotification);
+EUICC_API void
+es10b_notification_metadata_list_free_all(struct es10b_notification_metadata_list *notificationMetadataList);
+EUICC_API void es10b_pending_notification_free(struct es10b_pending_notification *PendingNotification);
 
-int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList);
-void es10b_rat_list_free_all(struct es10b_rat *ratList);
+EUICC_API int es10b_get_rat(struct euicc_ctx *ctx, struct es10b_rat **ratList);
+EUICC_API void es10b_rat_list_free_all(struct es10b_rat *ratList);

--- a/euicc/es10c.h
+++ b/euicc/es10c.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "euicc.h"
 
@@ -51,12 +52,12 @@ struct es10c_profile_info_list {
     struct es10c_profile_info_list *next;
 };
 
-int es10c_get_profiles_info(struct euicc_ctx *ctx, struct es10c_profile_info_list **profileInfoList);
-int es10c_enable_profile(struct euicc_ctx *ctx, const char *id, uint8_t refreshFlag);
-int es10c_disable_profile(struct euicc_ctx *ctx, const char *id, uint8_t refreshFlag);
-int es10c_delete_profile(struct euicc_ctx *ctx, const char *id);
-int es10c_euicc_memory_reset(struct euicc_ctx *ctx);
-int es10c_get_eid(struct euicc_ctx *ctx, char **eidValue);
-int es10c_set_nickname(struct euicc_ctx *ctx, const char *iccid, const char *profileNickname);
+EUICC_API int es10c_get_profiles_info(struct euicc_ctx *ctx, struct es10c_profile_info_list **profileInfoList);
+EUICC_API int es10c_enable_profile(struct euicc_ctx *ctx, const char *id, uint8_t refreshFlag);
+EUICC_API int es10c_disable_profile(struct euicc_ctx *ctx, const char *id, uint8_t refreshFlag);
+EUICC_API int es10c_delete_profile(struct euicc_ctx *ctx, const char *id);
+EUICC_API int es10c_euicc_memory_reset(struct euicc_ctx *ctx);
+EUICC_API int es10c_get_eid(struct euicc_ctx *ctx, char **eidValue);
+EUICC_API int es10c_set_nickname(struct euicc_ctx *ctx, const char *iccid, const char *profileNickname);
 
-void es10c_profile_info_list_free_all(struct es10c_profile_info_list *profileInfoList);
+EUICC_API void es10c_profile_info_list_free_all(struct es10c_profile_info_list *profileInfoList);

--- a/euicc/es10c_ex.h
+++ b/euicc/es10c_ex.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "euicc.h"
 
@@ -27,5 +28,5 @@ struct es10c_ex_euiccinfo2 {
     } certificationDataObject;
 };
 
-int es10c_ex_get_euiccinfo2(struct euicc_ctx *ctx, struct es10c_ex_euiccinfo2 *euiccinfo2);
-void es10c_ex_euiccinfo2_free(struct es10c_ex_euiccinfo2 *euiccinfo2);
+EUICC_API int es10c_ex_get_euiccinfo2(struct euicc_ctx *ctx, struct es10c_ex_euiccinfo2 *euiccinfo2);
+EUICC_API void es10c_ex_euiccinfo2_free(struct es10c_ex_euiccinfo2 *euiccinfo2);

--- a/euicc/es8p.h
+++ b/euicc/es8p.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "es10c.h"
 #include "euicc.h"
@@ -32,5 +33,5 @@ struct es8p_metadata_access_rule {
     struct es8p_metadata_access_rule *next;
 };
 
-int es8p_metadata_parse(struct es8p_metadata **metadata, const char *b64_Metadata);
-void es8p_metadata_free(struct es8p_metadata **stru_metadata);
+EUICC_API int es8p_metadata_parse(struct es8p_metadata **metadata, const char *b64_Metadata);
+EUICC_API void es8p_metadata_free(struct es8p_metadata **stru_metadata);

--- a/euicc/es9p.h
+++ b/euicc/es9p.h
@@ -1,30 +1,31 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "es10b.h"
 #include "euicc.h"
 
 #include <inttypes.h>
 
-int es9p_initiate_authentication_r(struct euicc_ctx *ctx, char **transaction_id,
-                                   struct es10b_authenticate_server_param *resp, const char *server_address,
-                                   const char *b64_euicc_challenge, const char *b64_euicc_info_1);
-int es9p_get_bound_profile_package_r(struct euicc_ctx *ctx, char **b64_bound_profile_package,
-                                     const char *server_address, const char *transaction_id,
-                                     const char *b64_prepare_download_response);
-int es9p_authenticate_client_r(struct euicc_ctx *ctx, struct es10b_prepare_download_param *resp,
-                               const char *server_address, const char *transaction_id,
-                               const char *b64_authenticate_server_response);
-int es9p_cancel_session_r(struct euicc_ctx *ctx, const char *server_address, const char *transaction_id,
-                          const char *b64_cancel_session_response);
+EUICC_API int es9p_initiate_authentication_r(struct euicc_ctx *ctx, char **transaction_id,
+                                             struct es10b_authenticate_server_param *resp, const char *server_address,
+                                             const char *b64_euicc_challenge, const char *b64_euicc_info_1);
+EUICC_API int es9p_get_bound_profile_package_r(struct euicc_ctx *ctx, char **b64_bound_profile_package,
+                                               const char *server_address, const char *transaction_id,
+                                               const char *b64_prepare_download_response);
+EUICC_API int es9p_authenticate_client_r(struct euicc_ctx *ctx, struct es10b_prepare_download_param *resp,
+                                         const char *server_address, const char *transaction_id,
+                                         const char *b64_authenticate_server_response);
+EUICC_API int es9p_cancel_session_r(struct euicc_ctx *ctx, const char *server_address, const char *transaction_id,
+                                    const char *b64_cancel_session_response);
 
-int es9p_initiate_authentication(struct euicc_ctx *ctx);
-int es9p_get_bound_profile_package(struct euicc_ctx *ctx);
-int es9p_authenticate_client(struct euicc_ctx *ctx);
-int es9p_cancel_session(struct euicc_ctx *ctx);
+EUICC_API int es9p_initiate_authentication(struct euicc_ctx *ctx);
+EUICC_API int es9p_get_bound_profile_package(struct euicc_ctx *ctx);
+EUICC_API int es9p_authenticate_client(struct euicc_ctx *ctx);
+EUICC_API int es9p_cancel_session(struct euicc_ctx *ctx);
 
-int es11_authenticate_client_r(struct euicc_ctx *ctx, char ***smdp_list, const char *server_address,
-                               const char *transaction_id, const char *b64_authenticate_server_response);
-int es11_authenticate_client(struct euicc_ctx *ctx, char ***smdp_list);
+EUICC_API int es11_authenticate_client_r(struct euicc_ctx *ctx, char ***smdp_list, const char *server_address,
+                                         const char *transaction_id, const char *b64_authenticate_server_response);
+EUICC_API int es11_authenticate_client(struct euicc_ctx *ctx, char ***smdp_list);
 
-int es9p_handle_notification(struct euicc_ctx *ctx, const char *b64_PendingNotification);
-void es11_smdp_list_free_all(char **smdp_list);
+EUICC_API int es9p_handle_notification(struct euicc_ctx *ctx, const char *b64_PendingNotification);
+EUICC_API void es11_smdp_list_free_all(char **smdp_list);

--- a/euicc/euicc.h
+++ b/euicc/euicc.h
@@ -52,6 +52,6 @@ struct euicc_ctx {
     void *userdata;
 };
 
-int euicc_init(struct euicc_ctx *ctx);
-void euicc_fini(struct euicc_ctx *ctx);
-void euicc_http_cleanup(struct euicc_ctx *ctx);
+EUICC_API int euicc_init(struct euicc_ctx *ctx);
+EUICC_API void euicc_fini(struct euicc_ctx *ctx);
+EUICC_API void euicc_http_cleanup(struct euicc_ctx *ctx);

--- a/euicc/euicc_export.h
+++ b/euicc/euicc_export.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if defined(_WIN32)
+#    ifdef LIBEUICC_EXPORTS
+#        define EUICC_API __declspec(dllexport)
+#    else
+#        define EUICC_API __declspec(dllimport)
+#    endif
+#else
+#    define EUICC_API
+#endif

--- a/euicc/hexutil.h
+++ b/euicc/hexutil.h
@@ -1,15 +1,18 @@
 #pragma once
+#include "euicc_export.h"
 
 #include <stdint.h>
 
-int euicc_hexutil_bin2hex(char *restrict output, uint32_t output_len, const uint8_t *restrict bin, uint32_t bin_len);
+EUICC_API int euicc_hexutil_bin2hex(char *restrict output, uint32_t output_len, const uint8_t *restrict bin,
+                                    uint32_t bin_len);
 
-int euicc_hexutil_hex2bin(uint8_t *restrict output, uint32_t output_len, const char *restrict input);
+EUICC_API int euicc_hexutil_hex2bin(uint8_t *restrict output, uint32_t output_len, const char *restrict input);
 
-int euicc_hexutil_hex2bin_r(uint8_t *restrict output, uint32_t output_len, const char *restrict input,
-                            uint32_t input_len);
+EUICC_API int euicc_hexutil_hex2bin_r(uint8_t *restrict output, uint32_t output_len, const char *restrict input,
+                                      uint32_t input_len);
 
-int euicc_hexutil_gsmbcd2bin(uint8_t *restrict output, uint32_t output_len, const char *restrict input,
-                             uint32_t padding_to);
+EUICC_API int euicc_hexutil_gsmbcd2bin(uint8_t *restrict output, uint32_t output_len, const char *restrict input,
+                                       uint32_t padding_to);
 
-int euicc_hexutil_bin2gsmbcd(char *restrict output, uint32_t output_len, const uint8_t *restrict bin, uint32_t bin_len);
+EUICC_API int euicc_hexutil_bin2gsmbcd(char *restrict output, uint32_t output_len, const uint8_t *restrict bin,
+                                       uint32_t bin_len);

--- a/euicc/logger.h
+++ b/euicc/logger.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "derutil.h"
 #include "interface.private.h"
@@ -6,12 +7,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void euicc_apdu_request_print(FILE *fp, const struct apdu_request *req, uint32_t req_len);
+EUICC_API void euicc_apdu_request_print(FILE *fp, const struct apdu_request *req, uint32_t req_len);
 
-void euicc_apdu_response_print(FILE *fp, const struct apdu_response *resp);
+EUICC_API void euicc_apdu_response_print(FILE *fp, const struct apdu_response *resp);
 
-void euicc_apdu_unhandled_tag_print(FILE *fp, const struct euicc_derutil_node *node);
+EUICC_API void euicc_apdu_unhandled_tag_print(FILE *fp, const struct euicc_derutil_node *node);
 
-void euicc_http_request_print(FILE *fp, const char *url, const char *tx);
+EUICC_API void euicc_http_request_print(FILE *fp, const char *url, const char *tx);
 
-void euicc_http_response_print(FILE *fp, uint32_t rcode, const char *rx);
+EUICC_API void euicc_http_response_print(FILE *fp, uint32_t rcode, const char *rx);

--- a/euicc/sha256.h
+++ b/euicc/sha256.h
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
+#include "euicc_export.h"
 // SPDX-License-Copyright: Brad Conte <brad@bradconte.com>
 // Original code from https://github.com/B-Con/crypto-algorithms/blob/02b66ec/sha256.h
 /*********************************************************************
@@ -10,13 +11,13 @@
  *********************************************************************/
 
 #ifndef SHA256_H
-#define SHA256_H
+#    define SHA256_H
 
 /*************************** HEADER FILES ***************************/
-#include <stddef.h>
+#    include <stddef.h>
 
 /****************************** MACROS ******************************/
-#define SHA256_BLOCK_SIZE 32 // SHA256 outputs a 32 byte digest
+#    define SHA256_BLOCK_SIZE 32 // SHA256 outputs a 32 byte digest
 
 /**************************** DATA TYPES ****************************/
 typedef unsigned char BYTE; // 8-bit byte
@@ -30,8 +31,9 @@ typedef struct {
 } EUICC_SHA256_CTX;
 
 /*********************** FUNCTION DECLARATIONS **********************/
-void euicc_sha256_init(EUICC_SHA256_CTX *ctx);
-void euicc_sha256_update(EUICC_SHA256_CTX *ctx, const BYTE data[], size_t len);
-void euicc_sha256_final(EUICC_SHA256_CTX *ctx, BYTE hash[]);
+
+EUICC_API void euicc_sha256_init(EUICC_SHA256_CTX *ctx);
+EUICC_API void euicc_sha256_update(EUICC_SHA256_CTX *ctx, const BYTE data[], size_t len);
+EUICC_API void euicc_sha256_final(EUICC_SHA256_CTX *ctx, BYTE hash[]);
 
 #endif // SHA256_H

--- a/euicc/tostr.h
+++ b/euicc/tostr.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "euicc_export.h"
 
 #include "es10b.h"
 #include "es10c.h"
@@ -6,9 +7,9 @@
 #include <inttypes.h>
 #include <stddef.h>
 
-const char *euicc_profilestate2str(enum es10c_profile_state value);
-const char *euicc_profileclass2str(enum es10c_profile_class value);
-const char *euicc_icontype2str(enum es10c_icon_type value);
-const char *euicc_profilemanagementoperation2str(enum es10b_profile_management_operation value);
-const char *euicc_bppcommandid2str(enum es10b_bpp_command_id value);
-const char *euicc_errorreason2str(enum es10b_error_reason value);
+EUICC_API const char *euicc_profilestate2str(enum es10c_profile_state value);
+EUICC_API const char *euicc_profileclass2str(enum es10c_profile_class value);
+EUICC_API const char *euicc_icontype2str(enum es10c_icon_type value);
+EUICC_API const char *euicc_profilemanagementoperation2str(enum es10b_profile_management_operation value);
+EUICC_API const char *euicc_bppcommandid2str(enum es10b_bpp_command_id value);
+EUICC_API const char *euicc_errorreason2str(enum es10b_error_reason value);

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,11 +1,10 @@
 add_library(lpac-utils SHARED lpac/utils.c)
+target_compile_definitions(lpac-utils PRIVATE LIBLPAC_UTILS_EXPORTS)
 install(TARGETS lpac-utils LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-target_link_libraries(lpac-utils PRIVATE ${CJSON_LIBRARY} euicc)
+target_link_libraries(lpac-utils PRIVATE ${CJSON_LIBRARY} cjson-ext euicc)
 target_compile_options(lpac-utils PRIVATE -Wall -Wextra)
 
 if(WIN32)
-    # Only useful on Windows, and will lead to invalid arguments on ld.gold.
-    target_link_options(lpac-utils PRIVATE "LINKER:--export-all-symbols")
     # FIXME: Glibc since 2.17 have move clock_* from librt to libc so
     #        single-thread program can use these functions without the
     #        overheads associated with multi-thread support.

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -5,6 +5,8 @@ target_link_libraries(lpac-utils PRIVATE ${CJSON_LIBRARY} cjson-ext euicc)
 target_compile_options(lpac-utils PRIVATE -Wall -Wextra)
 
 if(WIN32)
+    # To expose all missing dllimport/dllexport
+    target_link_options(lpac-utils PRIVATE "LINKER:--disable-auto-import")
     # FIXME: Glibc since 2.17 have move clock_* from librt to libc so
     #        single-thread program can use these functions without the
     #        overheads associated with multi-thread support.

--- a/utils/lpac/utils.h
+++ b/utils/lpac/utils.h
@@ -19,6 +19,16 @@
 #define APDU_ENV_NAME(DRIVER, NAME) ENV_APDU_DRIVER "_" #DRIVER "_" #NAME
 #define CUSTOM_ENV_NAME(NAME) "LPAC_CUSTOM_" #NAME
 
+#if defined(_WIN32)
+#    ifdef LIBLPAC_UTILS_EXPORTS
+#        define LPAC_API __declspec(dllexport)
+#    else
+#        define LPAC_API __declspec(dllimport)
+#    endif
+#else
+#    define LPAC_API __attribute__((visibility("default")))
+#endif
+
 #define _cleanup_(x) __attribute__((cleanup(x)))
 
 #define DEFINE_TRIVIAL_CLEANUP_FUNC(type, func) \
@@ -59,30 +69,30 @@ static inline void freep(void *p) { free(*(void **)p); }
         long: getenv_long_or_default,          \
         char *: getenv_str_or_default)(name, default_value)
 
-const char *getenv_str_or_default(const char *name, const char *default_value);
+LPAC_API const char *getenv_str_or_default(const char *name, const char *default_value);
 
-bool getenv_bool_or_default(const char *name, bool default_value);
+LPAC_API bool getenv_bool_or_default(const char *name, bool default_value);
 
-int getenv_int_or_default(const char *name, int default_value);
+LPAC_API int getenv_int_or_default(const char *name, int default_value);
 
-long getenv_long_or_default(const char *name, long default_value);
+LPAC_API long getenv_long_or_default(const char *name, long default_value);
 
-void set_deprecated_env_name(const char *name, const char *deprecated_name);
+LPAC_API void set_deprecated_env_name(const char *name, const char *deprecated_name);
 
-int str_to_bool(const char *value);
+LPAC_API int str_to_bool(const char *value);
 
-bool json_print(char *type, cJSON *jpayload);
+LPAC_API bool json_print(char *type, cJSON *jpayload);
 
-bool ends_with(const char *restrict str, const char *restrict suffix);
+LPAC_API bool ends_with(const char *restrict str, const char *restrict suffix);
 
-char *remove_suffix(char *restrict str, const char *restrict suffix);
+LPAC_API char *remove_suffix(char *restrict str, const char *restrict suffix);
 
-char **merge_array_of_str(char *left[], char *right[]);
+LPAC_API char **merge_array_of_str(char *left[], char *right[]);
 
-char *path_concat(const char *restrict a, const char *restrict b);
+LPAC_API char *path_concat(const char *restrict a, const char *restrict b);
 
-struct timespec get_current_clock(clockid_t clock_id);
+LPAC_API struct timespec get_current_clock(clockid_t clock_id);
 
-struct timespec get_duration(struct timespec t0, struct timespec t1);
+LPAC_API struct timespec get_duration(struct timespec t0, struct timespec t1);
 
-struct timespec get_wall_time(struct timespec wall);
+LPAC_API struct timespec get_wall_time(struct timespec wall);


### PR DESCRIPTION
--export-all-symbols can't deal with this issue.

fix #424

Signed-off-by: Coelacanthus <uwu@coelacanthus.name>