### PR TITLE
fix(at_helpers): handle AT responses without command prefix (fix FM350-GL)

### DIFF
--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -57,6 +57,7 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
 int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
+    _cleanup_free_ char *last_content_line = NULL;
     int result = -1;
 
     if (response)
@@ -126,12 +127,22 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
             found_response_data = strdup(line + strlen(expected));
             while (*found_response_data == ' ')
                 memmove(found_response_data, found_response_data + 1, strlen(found_response_data));
+        } else if (response && !found_response_data && strncasecmp(line, "AT", 2) != 0) {
+            // Fallback: save last non-echo content line for modems that return
+	    //	bare values without prefix (e.g. FM350-GL: "2\r\nOK" not "+CCHO: 2\r\nOK")
+            free(last_content_line);
+            last_content_line = strdup(line);
         }
     }
 end:
     if (result == 0 && response) {
-        *response = found_response_data;
-        found_response_data = NULL;
+        if (found_response_data) {
+            *response = found_response_data;
+            found_response_data = NULL;
+        } else if (last_content_line) {
+            *response = last_content_line;
+            last_content_line = NULL;
+        }
     }
     return result;
 }

--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -134,10 +134,8 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
     }
 end:
     if (result == 0 && response) {
-        if (found_response_data) {
-            *response = found_response_data;
-            found_response_data = NULL;
-        }
+        *response = found_response_data;
+        found_response_data = NULL;
     }
     return result;
 }

--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -57,7 +57,6 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
 int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
-    _cleanup_free_ char *last_content_line = NULL;
     int result = -1;
 
     if (response)
@@ -128,10 +127,9 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
             while (*found_response_data == ' ')
                 memmove(found_response_data, found_response_data + 1, strlen(found_response_data));
         } else if (response && !found_response_data && strncasecmp(line, "AT", 2) != 0) {
-            // Fallback: save last non-echo content line for modems that return
+            // Fallback: save non-echo content line for modems that return
 	    //	bare values without prefix (e.g. FM350-GL: "2\r\nOK" not "+CCHO: 2\r\nOK")
-            free(last_content_line);
-            last_content_line = strdup(line);
+            found_response_data = strdup(line);
         }
     }
 end:
@@ -139,9 +137,6 @@ end:
         if (found_response_data) {
             *response = found_response_data;
             found_response_data = NULL;
-        } else if (last_content_line) {
-            *response = last_content_line;
-            last_content_line = NULL;
         }
     }
     return result;


### PR DESCRIPTION
## Summary                                                                                                                                                                                   
                                                                                                                                                                                               
  Fix `at_expect()` to handle AT responses without the standard `+CMD:` prefix.
                                         
  ## Problem                                                                                                                                                                                   
                                         
  The FM350-GL returns bare values instead of prefixed responses on AT+CCHO:

```
AT+CCHO="A0000005591010FFFFFFFF8900000100"
2
OK
```

  The parser expects `+CCHO: 2` and returns NULL, breaking channel open and APDU transmit.

  ## Fix

  Save the last non-echo content line during parsing. When OK is received but no prefix match was found, fall back to the saved line. Transparent to modems that return standard prefixed responses.


  Related: #179, #209