### PR TITLE
fix: handling of notification with sequence number 0 correctly

### DIFF
--- a/src/applet/notification/dump.c
+++ b/src/applet/notification/dump.c
@@ -84,7 +84,7 @@ static int applet_main(const int argc, char **argv) {
             // Although POSIX said user should check errno instead of return value,
             // but errno may not be set when no conversion is performed according to C99.
             // Check nptr is same as str_end to ensure there is no conversion.
-            if ((seqNumber == 0 && strcmp(argv[i], str_end) != 0) || errno != 0) {
+            if (argv[i] == str_end || errno != 0) {
                 continue;
             }
             if (!retrieve_notification(eid, (uint32_t)seqNumber)) {

--- a/src/applet/notification/process.c
+++ b/src/applet/notification/process.c
@@ -109,7 +109,7 @@ static int applet_main(int argc, char **argv) {
             // Although POSIX said user should check errno instead of return value,
             // but errno may not be set when no conversion is performed according to C99.
             // Check nptr is same as str_end to ensure there is no conversion.
-            if ((seqNumber == 0 && strcmp(argv[i], str_end) != 0) || errno != 0) {
+            if (argv[i] == str_end || errno != 0) {
                 continue;
             }
             if (_process_single((uint32_t)seqNumber, autoremove)) {

--- a/src/applet/notification/remove.c
+++ b/src/applet/notification/remove.c
@@ -83,7 +83,7 @@ static int applet_main(int argc, char **argv) {
             // Although POSIX said user should check errno instead of return value,
             // but errno may not be set when no conversion is performed according to C99.
             // Check nptr is same as str_end to ensure there is no conversion.
-            if ((seqNumber == 0 && strcmp(argv[i], str_end)) || errno != 0) {
+            if (argv[i] == str_end || errno != 0) {
                 continue;
             }
 


### PR DESCRIPTION
Correctly check, if strtoul() converted the sequence number from command line to integer. A return value of 0 is not an error. Instead it successfully converted the command line argument to 0, unless the end pointer (str_end) equals the nptr.

This patch has been tested by processing and removing a notification with sequence number 0.