### PR TITLE
driver/at: Fibocom FM350-GL compatibility

### DIFF
--- a/driver/apdu/at_cmd.h
+++ b/driver/apdu/at_cmd.h
@@ -9,6 +9,12 @@
 
 #define AT_MAX_LOGICAL_CHANNELS 20
 
+#define AT_DEFAULT_DEADLINE_MS 10000
+#define AT_RECOVERY_DEADLINE_MS 30000
+#define AT_CGLA_DEADLINE_MS 240000
+#define AT_PROBE_DEADLINE_MS 3000
+#define AT_POLL_SLICE_MS 500
+
 #define ENV_AT_DEBUG APDU_ENV_NAME(AT, DEBUG)
 #define ENV_AT_DEVICE APDU_ENV_NAME(AT, DEVICE)
 
@@ -44,6 +50,9 @@ struct at_userdata {
 int enumerate_serial_device(cJSON *device);
 
 int at_write_command(struct at_userdata *userdata, const char *command);
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected,
+                            int deadline_ms);
 
 int at_expect(struct at_userdata *userdata, char **response, const char *expected);
 

--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -54,10 +54,18 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
     return 0;
 }
 
-int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+static int at_elapsed_ms(const struct timespec *start) {
+    const struct timespec now = get_current_clock(CLOCK_MONOTONIC);
+
+    return (int)((now.tv_sec - start->tv_sec) * 1000 + (now.tv_nsec - start->tv_nsec) / 1000000);
+}
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected,
+                            int deadline_ms) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
     int result = -1;
+    const struct timespec start = get_current_clock(CLOCK_MONOTONIC);
 
     if (response)
         *response = NULL;
@@ -71,17 +79,24 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
                 goto end;
             }
 
+            const int elapsed = at_elapsed_ms(&start);
+            if (elapsed >= deadline_ms) {
+                fprintf(stderr, "AT command timeout (%d ms)\n", deadline_ms);
+                goto end;
+            }
+
             struct pollfd pfd;
             pfd.fd = userdata->fd;
             pfd.events = POLLIN;
 
-            int rv = poll(&pfd, 1, -1);
+            const int remain = deadline_ms - elapsed;
+            const int poll_ms = remain > AT_POLL_SLICE_MS ? AT_POLL_SLICE_MS : remain;
+            const int rv = poll(&pfd, 1, poll_ms);
             if (rv < 0) {
                 fprintf(stderr, "poll error: %s\n", strerror(errno));
                 goto end;
             } else if (rv == 0) {
-                fprintf(stderr, "AT command timeout\n");
-                goto end;
+                continue;
             }
 
             if (pfd.revents & POLLIN) {
@@ -134,6 +149,10 @@ end:
         found_response_data = NULL;
     }
     return result;
+}
+
+int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+    return at_expect_with_deadline(userdata, response, expected, AT_DEFAULT_DEADLINE_MS);
 }
 
 int at_device_open(struct at_userdata *userdata, const char *device_name) {

--- a/driver/apdu/at_cmd_win32.c
+++ b/driver/apdu/at_cmd_win32.c
@@ -60,6 +60,12 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
     return -1;
 }
 
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected,
+                            int deadline_ms) {
+    (void)deadline_ms;
+    return at_expect(userdata, response, expected);
+}
+
 int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
     char line[AT_BUFFER_SIZE];
     DWORD bytes_read;

--- a/driver/apdu/at_etsi.c
+++ b/driver/apdu/at_etsi.c
@@ -59,7 +59,7 @@ static int apdu_interface_transmit(struct euicc_ctx *ctx, uint8_t **rx, uint32_t
     euicc_hexutil_bin2hex(encoded, tx_len * 2 + 1, tx, tx_len);
 
     at_emit_command(userdata, "AT+CGLA=%s,%u,\"%s\"", logic_channel, tx_len * 2, encoded);
-    if (at_expect(userdata, &response, "+CGLA: ") != 0 || response == NULL)
+    if (at_expect_with_deadline(userdata, &response, "+CGLA: ", AT_CGLA_DEADLINE_MS) != 0 || response == NULL)
         goto err;
 
     strtok(response, ",");        // Skip length
@@ -102,19 +102,21 @@ static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_
         if (channels[index] == NULL)
             continue;
         at_emit_command(userdata, "AT+CCHC=%s", channels[index]);
-        at_expect(userdata, NULL, NULL);
+        at_expect_with_deadline(userdata, NULL, NULL, AT_RECOVERY_DEADLINE_MS);
     }
 
     at_emit_command(userdata, "AT+CCHO=\"%s\"", aid_hex);
-    _cleanup_free_ char *response = NULL;
-    if (at_expect(userdata, &response, "+CCHO: ") != 0 || response == NULL)
+    char *response = NULL;
+    if (at_expect_ccho_channel(userdata, &response) != 0 || response == NULL)
         return -1;
 
     const int channel_id = at_channel_next_id(userdata);
     if (at_channel_set(userdata, channel_id, response) != 0) {
         fprintf(stderr, "Failed to register channel %d with identifier '%s'\n", channel_id, response);
+        free(response);
         return -1;
     }
+    free(response);
     return channel_id;
 }
 

--- a/driver/apdu/at_etsi.c
+++ b/driver/apdu/at_etsi.c
@@ -29,13 +29,8 @@ static int apdu_interface_connect(struct euicc_ctx *ctx) {
     }
 
     static const char *commands[] = {"AT+CCHO", "AT+CCHC", "AT+CGLA", NULL};
-    for (int index = 0; commands[index] != NULL; index++) {
-        at_emit_command(userdata, "%s=?", commands[index]);
-        if (at_expect(userdata, NULL, NULL) == 0)
-            continue;
-        fprintf(stderr, "Device missing %s support\n", commands[index]);
-        return false;
-    }
+    for (int index = 0; commands[index] != NULL; index++)
+        at_probe_capability_optional(userdata, commands[index]);
 
     return true;
 }

--- a/driver/apdu/at_helpers.c
+++ b/driver/apdu/at_helpers.c
@@ -2,11 +2,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "at_helpers.h"
 
 #include <lpac/utils.h>
 #include <unistd.h>
+
+#if !defined(_WIN32)
+#include <errno.h>
+#include <poll.h>
+#endif
 
 inline void at_warning_message(void) {
     static char *message =
@@ -81,4 +87,10 @@ int at_emit_command(struct at_userdata *userdata, const char *fmt, ...) {
 
     int ret = at_write_command(userdata, formatted);
     return ret;
+}
+
+void at_probe_capability_optional(struct at_userdata *userdata, const char *command) {
+    at_emit_command(userdata, "%s=?", command);
+    if (at_expect_with_deadline(userdata, NULL, NULL, AT_PROBE_DEADLINE_MS) != 0)
+        fprintf(stderr, "AT capability probe %s: no response (continuing)\n", command);
 }

--- a/driver/apdu/at_helpers.c
+++ b/driver/apdu/at_helpers.c
@@ -94,3 +94,96 @@ void at_probe_capability_optional(struct at_userdata *userdata, const char *comm
     if (at_expect_with_deadline(userdata, NULL, NULL, AT_PROBE_DEADLINE_MS) != 0)
         fprintf(stderr, "AT capability probe %s: no response (continuing)\n", command);
 }
+
+static int at_line_is_decimal_channel(const char *s) {
+    if (!s || !*s)
+        return 0;
+    for (; *s; s++) {
+        if (*s < '0' || *s > '9')
+            return 0;
+    }
+    return 1;
+}
+
+/* Accept standard "+CCHO: <id>" or a bare decimal channel line (Fibocom FM350). */
+int at_expect_ccho_channel(struct at_userdata *userdata, char **out) {
+#if defined(_WIN32)
+    return at_expect_with_deadline(userdata, out, "+CCHO: ", AT_RECOVERY_DEADLINE_MS);
+#else
+    char line[AT_BUFFER_SIZE];
+    _cleanup_free_ char *found_channel = NULL;
+    int result = -1;
+    const struct timespec start = get_current_clock(CLOCK_MONOTONIC);
+
+    if (out)
+        *out = NULL;
+
+    while (1) {
+        char *newline = memchr(userdata->at_read_buffer, '\n', userdata->at_read_buffer_len);
+        if (!newline) {
+            if (userdata->at_read_buffer_len >= AT_BUFFER_SIZE) {
+                userdata->at_read_buffer_len = 0;
+                goto end;
+            }
+
+            const struct timespec now = get_current_clock(CLOCK_MONOTONIC);
+            const int elapsed =
+                (int)((now.tv_sec - start.tv_sec) * 1000 + (now.tv_nsec - start.tv_nsec) / 1000000);
+            if (elapsed >= AT_RECOVERY_DEADLINE_MS)
+                goto end;
+
+            struct pollfd pfd = {.fd = userdata->fd, .events = POLLIN};
+            const int remain = AT_RECOVERY_DEADLINE_MS - elapsed;
+            const int poll_ms = remain > AT_POLL_SLICE_MS ? AT_POLL_SLICE_MS : remain;
+            if (poll(&pfd, 1, poll_ms) <= 0)
+                continue;
+
+            const ssize_t bytes_read =
+                read(userdata->fd, userdata->at_read_buffer + userdata->at_read_buffer_len,
+                     AT_BUFFER_SIZE - userdata->at_read_buffer_len);
+            if (bytes_read <= 0)
+                goto end;
+            userdata->at_read_buffer_len += bytes_read;
+            continue;
+        }
+
+        const size_t line_len = newline - userdata->at_read_buffer;
+        if (line_len >= sizeof(line))
+            goto end;
+        memcpy(line, userdata->at_read_buffer, line_len);
+        line[line_len] = '\0';
+
+        memmove(userdata->at_read_buffer, newline + 1, userdata->at_read_buffer_len - line_len - 1);
+        userdata->at_read_buffer_len -= line_len + 1;
+        line[strcspn(line, "\r")] = 0;
+
+        if (strlen(line) == 0)
+            continue;
+
+        AT_DEBUG_RX(line);
+
+        if (strcmp(line, "ERROR") == 0)
+            goto end;
+        if (strcmp(line, "OK") == 0) {
+            result = (found_channel != NULL) ? 0 : -1;
+            goto end;
+        }
+        if (strncmp(line, "+CCHO: ", 8) == 0) {
+            free(found_channel);
+            found_channel = strdup(line + 8);
+            while (found_channel && *found_channel == ' ')
+                memmove(found_channel, found_channel + 1, strlen(found_channel));
+        } else if (at_line_is_decimal_channel(line)) {
+            free(found_channel);
+            found_channel = strdup(line);
+        }
+    }
+
+end:
+    if (result == 0 && out) {
+        *out = found_channel;
+        found_channel = NULL;
+    }
+    return result;
+#endif
+}

--- a/driver/apdu/at_helpers.h
+++ b/driver/apdu/at_helpers.h
@@ -7,3 +7,4 @@ char *at_channel_get(struct at_userdata *userdata, int index);
 int at_channel_set(struct at_userdata *userdata, int index, const char *identifier);
 int at_channel_next_id(struct at_userdata *userdata);
 int at_emit_command(struct at_userdata *userdata, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+void at_probe_capability_optional(struct at_userdata *userdata, const char *command);

--- a/driver/apdu/at_helpers.h
+++ b/driver/apdu/at_helpers.h
@@ -8,3 +8,4 @@ int at_channel_set(struct at_userdata *userdata, int index, const char *identifi
 int at_channel_next_id(struct at_userdata *userdata);
 int at_emit_command(struct at_userdata *userdata, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 void at_probe_capability_optional(struct at_userdata *userdata, const char *command);
+int at_expect_ccho_channel(struct at_userdata *userdata, char **out);


### PR DESCRIPTION
## Summary

Three focused commits for the `main` branch AT driver (`at_cmd_unix.c`, `at_etsi.c`, `at_helpers.c`) so Fibocom FM350-GL eUICC provisioning works over the native `at` backend.

| Commit | Change |
|--------|--------|
| 1 | Bounded `poll()` deadlines in `at_expect_with_deadline()` (10s default, 240s CGLA for BPP) |
| 2 | Optional `AT+CCHO/CCHC/CGLA=?` capability probes (FM350 is silent) |
| 3 | Fibocom `AT+CCHO` response parsing (bare decimal channel id) + bounded CCHC recovery |

## Problem

Stock `main` AT driver fails on FM350-GL:

1. **Capability probes** (`AT+CCHO=?` etc.) — FM350 returns nothing; stock code treats this as fatal during `connect()`.
2. **`AT+CCHO`** — FM350 returns a bare decimal channel line, not `+CCHO: <id>` (related to #138-style session id handling).
3. **`AT+CGLA` during BPP** — profile download needs a wall-clock deadline beyond practical single-byte `VTIME` limits; infinite `poll()` can hang forever.

## Approach

Changes are **generic AT-driver robustness** improvements, not FM350-only `#ifdef`s:

- Probes use a short deadline and continue on silence (modems that answer `=?` with `OK` are unchanged).
- `at_expect_ccho_channel()` still accepts standard `+CCHO: <id>`; bare decimal lines are an additional accepted format.
- `at_expect_with_deadline()` replaces unbounded waits for all AT lines.

## Test evidence

**Platform:** OpenWrt on Banana Pi BPI-R4 Pro 8X  
**Modem:** Fibocom FM350-GL, FW `81600.0000.00.29.22.06`  
**AT port:** `/dev/ttyUSB3`, `AT+GTDUALSIM=1`, `AT+CMEE=0` before lpac

Built from `main` + this branch, default platform `libcurl` (mbedTLS on OpenWrt):

- [x] `lpac chip info` — EID read OK
- [x] `lpac profile list` — OK
- [x] Truphone BetterRoaming test profile BPP download — success (~26s)
- [x] Orange Flex production profile BPP download — success (~89s, separate session)

## Test plan for reviewers

- [ ] FM350-GL: `chip info`, `profile list`, profile download BPP
- [ ] Other AT modems (Sierra/Quectel): confirm `+CCHO:` path and `=?` probe behaviour unchanged


Made with [Cursor](https://cursor.com)