### PR TITLE
driver/at: accept Fibocom FM350 bare-decimal AT+CCHO response

### DIFF
--- a/driver/apdu/at_cmd.h
+++ b/driver/apdu/at_cmd.h
@@ -53,6 +53,11 @@ int at_write_command(struct at_userdata *userdata, const char *command);
 
 int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms);
 
+/* Like at_expect_with_deadline(), but a line that doesn't match `expected` is still
+ * captured as the response when is_fallback_match(line) returns non-zero for it. */
+int at_expect_with_deadline_ex(struct at_userdata *userdata, char **response, const char *expected,
+                               int (*is_fallback_match)(const char *line), int deadline_ms);
+
 int at_expect(struct at_userdata *userdata, char **response, const char *expected);
 
 int at_device_open(struct at_userdata *userdata, const char *device_name);

--- a/driver/apdu/at_cmd.h
+++ b/driver/apdu/at_cmd.h
@@ -9,6 +9,12 @@
 
 #define AT_MAX_LOGICAL_CHANNELS 20
 
+#define AT_DEFAULT_DEADLINE_MS 10000
+#define AT_RECOVERY_DEADLINE_MS 30000
+#define AT_CGLA_DEADLINE_MS 240000
+#define AT_PROBE_DEADLINE_MS 3000
+#define AT_POLL_SLICE_MS 500
+
 #define ENV_AT_DEBUG APDU_ENV_NAME(AT, DEBUG)
 #define ENV_AT_DEVICE APDU_ENV_NAME(AT, DEVICE)
 
@@ -44,6 +50,8 @@ struct at_userdata {
 int enumerate_serial_device(cJSON *device);
 
 int at_write_command(struct at_userdata *userdata, const char *command);
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms);
 
 int at_expect(struct at_userdata *userdata, char **response, const char *expected);
 

--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -16,6 +16,15 @@
 #include <unistd.h>
 
 #if defined(__linux__)
+#    include <sys/timerfd.h>
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) \
+    || defined(__DragonFly__)
+#    include <sys/event.h>
+#    include <sys/time.h>
+#    define AT_HAVE_KQUEUE 1
+#endif
+
+#if defined(__linux__)
 int enumerate_serial_device(cJSON *devices) {
     const char *dir_path = "/dev/serial/by-id";
     DIR *dir = opendir(dir_path);
@@ -54,7 +63,52 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
     return 0;
 }
 
-int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+/* Extracts the next complete line from `buf` into `line`, decoupled from at_userdata.
+ * Returns 0 on success, -1 if no complete line is buffered yet. */
+static int at_pop_line(char *buf, size_t *buf_len, char *line, size_t line_size) {
+    char *newline = memchr(buf, '\n', *buf_len);
+    if (!newline)
+        return -1;
+
+    size_t line_len = newline - buf;
+    if (line_len >= line_size)
+        line_len = line_size - 1;
+    memcpy(line, buf, line_len);
+    line[line_len] = '\0';
+
+    memmove(buf, newline + 1, *buf_len - line_len - 1);
+    *buf_len -= line_len + 1;
+
+    line[strcspn(line, "\r")] = 0;
+    return 0;
+}
+
+/* Applies AT response bookkeeping to an already-extracted `line`.
+ * Returns 1 to keep reading, 0 once `result` is final. */
+static int at_match_line(const char *line, const char *expected, char **found_response_data, int *result) {
+    if (strlen(line) == 0)
+        return 1;
+
+    if (strcmp(line, "ERROR") == 0) {
+        *result = -1;
+        return 0;
+    }
+    if (strcmp(line, "OK") == 0) {
+        *result = 0;
+        return 0;
+    }
+
+    if (expected && strncmp(line, expected, strlen(expected)) == 0) {
+        free(*found_response_data);
+        *found_response_data = strdup(line + strlen(expected));
+        while (*found_response_data && (*found_response_data)[0] == ' ')
+            memmove(*found_response_data, *found_response_data + 1, strlen(*found_response_data));
+    }
+    return 1;
+}
+
+#if defined(__linux__)
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
     int result = -1;
@@ -62,70 +116,197 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
     if (response)
         *response = NULL;
 
+    const int timer_fd = timerfd_create(CLOCK_MONOTONIC, 0);
+    if (timer_fd < 0) {
+        fprintf(stderr, "timerfd_create error: %s\n", strerror(errno));
+        return -1;
+    }
+
+    const struct itimerspec its = {
+        .it_value = {.tv_sec = deadline_ms / 1000, .tv_nsec = (long)(deadline_ms % 1000) * 1000000L},
+    };
+    if (timerfd_settime(timer_fd, 0, &its, NULL) < 0) {
+        fprintf(stderr, "timerfd_settime error: %s\n", strerror(errno));
+        close(timer_fd);
+        return -1;
+    }
+
     while (1) {
-        char *newline = memchr(userdata->at_read_buffer, '\n', userdata->at_read_buffer_len);
-        if (!newline) {
-            if (userdata->at_read_buffer_len >= AT_BUFFER_SIZE) {
-                fprintf(stderr, "AT response line too long or buffer full\n");
-                userdata->at_read_buffer_len = 0;
+        if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
+            AT_DEBUG_RX(line);
+            if (!at_match_line(line, expected, &found_response_data, &result))
                 goto end;
-            }
-
-            struct pollfd pfd;
-            pfd.fd = userdata->fd;
-            pfd.events = POLLIN;
-
-            int rv = poll(&pfd, 1, -1);
-            if (rv < 0) {
-                fprintf(stderr, "poll error: %s\n", strerror(errno));
-                goto end;
-            } else if (rv == 0) {
-                fprintf(stderr, "AT command timeout\n");
-                goto end;
-            }
-
-            if (pfd.revents & POLLIN) {
-                ssize_t bytes_read = read(userdata->fd, userdata->at_read_buffer + userdata->at_read_buffer_len,
-                                          AT_BUFFER_SIZE - userdata->at_read_buffer_len);
-                if (bytes_read <= 0) {
-                    fprintf(stderr, "read error or connection closed\n");
-                    goto end;
-                }
-                userdata->at_read_buffer_len += bytes_read;
-            }
             continue;
         }
 
-        size_t line_len = newline - userdata->at_read_buffer;
-        if (line_len >= sizeof(line))
-            line_len = sizeof(line) - 1;
-        memcpy(line, userdata->at_read_buffer, line_len);
-        line[line_len] = '\0';
+        if (userdata->at_read_buffer_len >= AT_BUFFER_SIZE) {
+            fprintf(stderr, "AT response line too long or buffer full\n");
+            userdata->at_read_buffer_len = 0;
+            goto end;
+        }
 
-        memmove(userdata->at_read_buffer, newline + 1, userdata->at_read_buffer_len - line_len - 1);
-        userdata->at_read_buffer_len -= line_len + 1;
+        struct pollfd pfds[2];
+        pfds[0].fd = userdata->fd;
+        pfds[0].events = POLLIN;
+        pfds[1].fd = timer_fd;
+        pfds[1].events = POLLIN;
 
-        line[strcspn(line, "\r")] = 0;
+        const int rv = poll(pfds, 2, -1);
+        if (rv < 0) {
+            fprintf(stderr, "poll error: %s\n", strerror(errno));
+            goto end;
+        }
 
-        if (strlen(line) == 0)
+        if (pfds[1].revents & POLLIN) {
+            fprintf(stderr, "AT command timeout (%d ms)\n", deadline_ms);
+            goto end;
+        }
+
+        if (pfds[0].revents & POLLIN) {
+            ssize_t bytes_read = read(userdata->fd, userdata->at_read_buffer + userdata->at_read_buffer_len,
+                                      AT_BUFFER_SIZE - userdata->at_read_buffer_len);
+            if (bytes_read <= 0) {
+                fprintf(stderr, "read error or connection closed\n");
+                goto end;
+            }
+            userdata->at_read_buffer_len += bytes_read;
+        }
+    }
+end:
+    close(timer_fd);
+    if (result == 0 && response) {
+        *response = found_response_data;
+        found_response_data = NULL;
+    }
+    return result;
+}
+#elif defined(AT_HAVE_KQUEUE)
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+    char line[AT_BUFFER_SIZE];
+    _cleanup_free_ char *found_response_data = NULL;
+    int result = -1;
+
+    if (response)
+        *response = NULL;
+
+    const int kq = kqueue();
+    if (kq < 0) {
+        fprintf(stderr, "kqueue error: %s\n", strerror(errno));
+        return -1;
+    }
+
+    /* No NOTE_MSECONDS: EVFILT_TIMER defaults to ms without a NOTE_*SECONDS flag. */
+    struct kevent changes[2];
+    EV_SET(&changes[0], userdata->fd, EVFILT_READ, EV_ADD, 0, 0, NULL);
+    EV_SET(&changes[1], (uintptr_t)userdata, EVFILT_TIMER, EV_ADD | EV_ONESHOT, 0, deadline_ms, NULL);
+    if (kevent(kq, changes, 2, NULL, 0, NULL) < 0) {
+        fprintf(stderr, "kevent register error: %s\n", strerror(errno));
+        close(kq);
+        return -1;
+    }
+
+    while (1) {
+        if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
+            AT_DEBUG_RX(line);
+            if (!at_match_line(line, expected, &found_response_data, &result))
+                goto end;
             continue;
-
-        AT_DEBUG_RX(line);
-
-        if (strcmp(line, "ERROR") == 0) {
-            result = -1;
-            goto end;
         }
-        if (strcmp(line, "OK") == 0) {
-            result = 0;
+
+        if (userdata->at_read_buffer_len >= AT_BUFFER_SIZE) {
+            fprintf(stderr, "AT response line too long or buffer full\n");
+            userdata->at_read_buffer_len = 0;
             goto end;
         }
 
-        if (expected && strncmp(line, expected, strlen(expected)) == 0) {
-            free(found_response_data);
-            found_response_data = strdup(line + strlen(expected));
-            while (*found_response_data == ' ')
-                memmove(found_response_data, found_response_data + 1, strlen(found_response_data));
+        struct kevent event;
+        const int nev = kevent(kq, NULL, 0, &event, 1, NULL);
+        if (nev < 0) {
+            fprintf(stderr, "kevent error: %s\n", strerror(errno));
+            goto end;
+        }
+
+        if (event.filter == EVFILT_TIMER) {
+            fprintf(stderr, "AT command timeout (%d ms)\n", deadline_ms);
+            goto end;
+        }
+
+        if (event.filter == EVFILT_READ) {
+            ssize_t bytes_read = read(userdata->fd, userdata->at_read_buffer + userdata->at_read_buffer_len,
+                                      AT_BUFFER_SIZE - userdata->at_read_buffer_len);
+            if (bytes_read <= 0) {
+                fprintf(stderr, "read error or connection closed\n");
+                goto end;
+            }
+            userdata->at_read_buffer_len += bytes_read;
+        }
+    }
+end:
+    close(kq);
+    if (result == 0 && response) {
+        *response = found_response_data;
+        found_response_data = NULL;
+    }
+    return result;
+}
+#else
+static int at_elapsed_ms(const struct timespec *start) {
+    const struct timespec now = get_current_clock(CLOCK_MONOTONIC);
+
+    return (int)((now.tv_sec - start->tv_sec) * 1000 + (now.tv_nsec - start->tv_nsec) / 1000000);
+}
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+    char line[AT_BUFFER_SIZE];
+    _cleanup_free_ char *found_response_data = NULL;
+    int result = -1;
+    const struct timespec start = get_current_clock(CLOCK_MONOTONIC);
+
+    if (response)
+        *response = NULL;
+
+    while (1) {
+        if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
+            AT_DEBUG_RX(line);
+            if (!at_match_line(line, expected, &found_response_data, &result))
+                goto end;
+            continue;
+        }
+
+        if (userdata->at_read_buffer_len >= AT_BUFFER_SIZE) {
+            fprintf(stderr, "AT response line too long or buffer full\n");
+            userdata->at_read_buffer_len = 0;
+            goto end;
+        }
+
+        const int elapsed = at_elapsed_ms(&start);
+        if (elapsed >= deadline_ms) {
+            fprintf(stderr, "AT command timeout (%d ms)\n", deadline_ms);
+            goto end;
+        }
+
+        struct pollfd pfd;
+        pfd.fd = userdata->fd;
+        pfd.events = POLLIN;
+
+        const int remain = deadline_ms - elapsed;
+        const int poll_ms = remain > AT_POLL_SLICE_MS ? AT_POLL_SLICE_MS : remain;
+        const int rv = poll(&pfd, 1, poll_ms);
+        if (rv < 0) {
+            fprintf(stderr, "poll error: %s\n", strerror(errno));
+            goto end;
+        } else if (rv == 0) {
+            continue;
+        }
+
+        if (pfd.revents & POLLIN) {
+            ssize_t bytes_read = read(userdata->fd, userdata->at_read_buffer + userdata->at_read_buffer_len,
+                                      AT_BUFFER_SIZE - userdata->at_read_buffer_len);
+            if (bytes_read <= 0) {
+                fprintf(stderr, "read error or connection closed\n");
+                goto end;
+            }
+            userdata->at_read_buffer_len += bytes_read;
         }
     }
 end:
@@ -134,6 +315,11 @@ end:
         found_response_data = NULL;
     }
     return result;
+}
+#endif
+
+int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+    return at_expect_with_deadline(userdata, response, expected, AT_DEFAULT_DEADLINE_MS);
 }
 
 int at_device_open(struct at_userdata *userdata, const char *device_name) {

--- a/driver/apdu/at_cmd_unix.c
+++ b/driver/apdu/at_cmd_unix.c
@@ -83,9 +83,11 @@ static int at_pop_line(char *buf, size_t *buf_len, char *line, size_t line_size)
     return 0;
 }
 
-/* Applies AT response bookkeeping to an already-extracted `line`.
+/* Applies AT response bookkeeping to an already-extracted `line`, with an optional
+ * is_fallback_match() capture for lines that don't match `expected`.
  * Returns 1 to keep reading, 0 once `result` is final. */
-static int at_match_line(const char *line, const char *expected, char **found_response_data, int *result) {
+static int at_match_line(const char *line, const char *expected, int (*is_fallback_match)(const char *line),
+                         char **found_response_data, int *result) {
     if (strlen(line) == 0)
         return 1;
 
@@ -103,12 +105,16 @@ static int at_match_line(const char *line, const char *expected, char **found_re
         *found_response_data = strdup(line + strlen(expected));
         while (*found_response_data && (*found_response_data)[0] == ' ')
             memmove(*found_response_data, *found_response_data + 1, strlen(*found_response_data));
+    } else if (is_fallback_match && is_fallback_match(line)) {
+        free(*found_response_data);
+        *found_response_data = strdup(line);
     }
     return 1;
 }
 
 #if defined(__linux__)
-int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+int at_expect_with_deadline_ex(struct at_userdata *userdata, char **response, const char *expected,
+                               int (*is_fallback_match)(const char *line), int deadline_ms) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
     int result = -1;
@@ -134,7 +140,7 @@ int at_expect_with_deadline(struct at_userdata *userdata, char **response, const
     while (1) {
         if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
             AT_DEBUG_RX(line);
-            if (!at_match_line(line, expected, &found_response_data, &result))
+            if (!at_match_line(line, expected, is_fallback_match, &found_response_data, &result))
                 goto end;
             continue;
         }
@@ -181,7 +187,8 @@ end:
     return result;
 }
 #elif defined(AT_HAVE_KQUEUE)
-int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+int at_expect_with_deadline_ex(struct at_userdata *userdata, char **response, const char *expected,
+                               int (*is_fallback_match)(const char *line), int deadline_ms) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
     int result = -1;
@@ -208,7 +215,7 @@ int at_expect_with_deadline(struct at_userdata *userdata, char **response, const
     while (1) {
         if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
             AT_DEBUG_RX(line);
-            if (!at_match_line(line, expected, &found_response_data, &result))
+            if (!at_match_line(line, expected, is_fallback_match, &found_response_data, &result))
                 goto end;
             continue;
         }
@@ -256,7 +263,8 @@ static int at_elapsed_ms(const struct timespec *start) {
     return (int)((now.tv_sec - start->tv_sec) * 1000 + (now.tv_nsec - start->tv_nsec) / 1000000);
 }
 
-int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+int at_expect_with_deadline_ex(struct at_userdata *userdata, char **response, const char *expected,
+                               int (*is_fallback_match)(const char *line), int deadline_ms) {
     char line[AT_BUFFER_SIZE];
     _cleanup_free_ char *found_response_data = NULL;
     int result = -1;
@@ -268,7 +276,7 @@ int at_expect_with_deadline(struct at_userdata *userdata, char **response, const
     while (1) {
         if (at_pop_line(userdata->at_read_buffer, &userdata->at_read_buffer_len, line, sizeof(line)) == 0) {
             AT_DEBUG_RX(line);
-            if (!at_match_line(line, expected, &found_response_data, &result))
+            if (!at_match_line(line, expected, is_fallback_match, &found_response_data, &result))
                 goto end;
             continue;
         }
@@ -317,6 +325,10 @@ end:
     return result;
 }
 #endif
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+    return at_expect_with_deadline_ex(userdata, response, expected, NULL, deadline_ms);
+}
 
 int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
     return at_expect_with_deadline(userdata, response, expected, AT_DEFAULT_DEADLINE_MS);

--- a/driver/apdu/at_cmd_win32.c
+++ b/driver/apdu/at_cmd_win32.c
@@ -60,12 +60,8 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
     return -1;
 }
 
-int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
-    (void)deadline_ms;
-    return at_expect(userdata, response, expected);
-}
-
-int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+static int at_expect_core(struct at_userdata *userdata, char **response, const char *expected,
+                          int (*is_fallback_match)(const char *line)) {
     char line[AT_BUFFER_SIZE];
     DWORD bytes_read;
     _cleanup_free_ char *found_response_data = NULL;
@@ -129,6 +125,9 @@ int at_expect(struct at_userdata *userdata, char **response, const char *expecte
         if (expected && strncmp(line, expected, strlen(expected)) == 0) {
             free(found_response_data);
             found_response_data = strdup(line + strlen(expected));
+        } else if (is_fallback_match && is_fallback_match(line)) {
+            free(found_response_data);
+            found_response_data = strdup(line);
         }
     }
 
@@ -138,6 +137,21 @@ end:
         found_response_data = NULL;
     }
     return result;
+}
+
+int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
+    return at_expect_core(userdata, response, expected, NULL);
+}
+
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+    (void)deadline_ms;
+    return at_expect_core(userdata, response, expected, NULL);
+}
+
+int at_expect_with_deadline_ex(struct at_userdata *userdata, char **response, const char *expected,
+                               int (*is_fallback_match)(const char *line), int deadline_ms) {
+    (void)deadline_ms;
+    return at_expect_core(userdata, response, expected, is_fallback_match);
 }
 
 int at_device_open(struct at_userdata *userdata, const char *device_name) {

--- a/driver/apdu/at_cmd_win32.c
+++ b/driver/apdu/at_cmd_win32.c
@@ -60,6 +60,11 @@ int at_write_command(struct at_userdata *userdata, const char *command) {
     return -1;
 }
 
+int at_expect_with_deadline(struct at_userdata *userdata, char **response, const char *expected, int deadline_ms) {
+    (void)deadline_ms;
+    return at_expect(userdata, response, expected);
+}
+
 int at_expect(struct at_userdata *userdata, char **response, const char *expected) {
     char line[AT_BUFFER_SIZE];
     DWORD bytes_read;

--- a/driver/apdu/at_etsi.c
+++ b/driver/apdu/at_etsi.c
@@ -112,7 +112,7 @@ static int apdu_interface_logic_channel_open(struct euicc_ctx *ctx, const uint8_
 
     at_emit_command(userdata, "AT+CCHO=\"%s\"", aid_hex);
     _cleanup_free_ char *response = NULL;
-    if (at_expect(userdata, &response, "+CCHO: ") != 0 || response == NULL)
+    if (at_expect_ccho_channel(userdata, &response) != 0 || response == NULL)
         return -1;
 
     const int channel_id = at_channel_next_id(userdata);

--- a/driver/apdu/at_helpers.c
+++ b/driver/apdu/at_helpers.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -81,4 +82,20 @@ int at_emit_command(struct at_userdata *userdata, const char *fmt, ...) {
 
     int ret = at_write_command(userdata, formatted);
     return ret;
+}
+
+static int at_line_is_decimal_channel(const char *line) {
+    if (!line || !*line)
+        return 0;
+    for (; *line; line++) {
+        if (!isdigit((unsigned char)*line))
+            return 0;
+    }
+    return 1;
+}
+
+/* Fibocom FM350-GL answers AT+CCHO with a bare decimal channel line instead of the
+ * standard "+CCHO: <id>". Accept either. */
+int at_expect_ccho_channel(struct at_userdata *userdata, char **out) {
+    return at_expect_with_deadline_ex(userdata, out, "+CCHO: ", at_line_is_decimal_channel, AT_RECOVERY_DEADLINE_MS);
 }

--- a/driver/apdu/at_helpers.h
+++ b/driver/apdu/at_helpers.h
@@ -7,3 +7,4 @@ char *at_channel_get(struct at_userdata *userdata, int index);
 int at_channel_set(struct at_userdata *userdata, int index, const char *identifier);
 int at_channel_next_id(struct at_userdata *userdata);
 int at_emit_command(struct at_userdata *userdata, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+int at_expect_ccho_channel(struct at_userdata *userdata, char **out);


### PR DESCRIPTION
## Summary

Fourth of 4 focused PRs replacing #442 (see #446 for the first). Stacked on #446 — the diff below includes that PR's commit until it merges; only the last commit ("accept Fibocom FM350 bare-decimal AT+CCHO response") is new here.

Fibocom FM350-GL answers `AT+CCHO` with a bare decimal channel line instead of the standard `+CCHO: <id>`. This is the one genuinely device-specific quirk in the original #442, isolated into its own PR so it can be reviewed/argued separately from the generic robustness fixes in #446/#447/#448.

Addresses the review feedback on #442 directly:
- Adds a generic fallback-match hook to `at_expect_with_deadline()` (`at_expect_with_deadline_ex()`) so a line that doesn't match the expected prefix can still be captured as the response when a caller-supplied predicate accepts it, **instead of hand-rolling a second copy of the read/poll loop per platform** ([per this feedback](https://github.com/estkme-group/lpac/pull/442#discussion_r3409811484)). `at_expect_ccho_channel()` is now a one-line wrapper; there's no `#ifdef _WIN32` in `at_helpers.c` at all, and the Windows backend gets the same bare-decimal acceptance for free instead of silently lacking it.
- Uses `isdigit()` instead of a manual digit-range loop ([per this feedback](https://github.com/estkme-group/lpac/pull/442#discussion_r3409809191)).
- Keeps the existing `_cleanup_free_` SBRM pattern in `apdu_interface_logic_channel_open` intact ([per this feedback](https://github.com/estkme-group/lpac/pull/442#discussion_r3409802647)) — #442 had swapped it for manual `free()` calls, which wasn't needed for this fix.

## Test plan

- [x] Builds clean
- [ ] Fibocom FM350-GL: `AT+CCHO` bare-decimal response accepted, logical channel opens
- [ ] Other AT modems: confirm standard `+CCHO: <id>` responses are unaffected