### PR TITLE
fix(profile/discovery): parse every command-line option

### DIFF
--- a/src/applet/profile/discovery.c
+++ b/src/applet/profile/discovery.c
@@ -42,7 +42,6 @@ static int applet_main(int argc, char **argv) {
             return -1;
             break;
         }
-        opt = getopt(argc, argv, opt_string);
     }
 
     if (smds == NULL) {


### PR DESCRIPTION
The profile discovery option loop calls `getopt()` in the `while` condition and again at the end of each iteration. The second call consumes every other option without passing it through the `switch`.

For example:

```text
lpac profile discovery -s smds.example.test -i 490154203237518
```

The `-s` option is processed, while `-i` is consumed by the redundant call and ignored.