### PR TITLE
fix(profile/download): always require interactive preview approval

### DIFF
--- a/src/applet/profile/download.c
+++ b/src/applet/profile/download.c
@@ -275,14 +275,14 @@ static int applet_main(int argc, char **argv) {
         }
 
         jprint_progress_obj("es8p_metadata_parse", jmetadata);
+    }
 
-        if (interactive_preview) {
-            int c;
-            jprint_progress("preview", "y/n");
-            c = getchar();
-            if (c != 'y' && c != 'Y') {
-                cancelled = 1;
-            }
+    if (interactive_preview) {
+        int c;
+        jprint_progress("preview", "y/n");
+        c = getchar();
+        if (c != 'y' && c != 'Y') {
+            cancelled = 1;
         }
     }
 


### PR DESCRIPTION
`lpac profile download -p` currently asks for confirmation only when the provider returns profile metadata. If metadata is absent, the command proceeds to `es10b_prepare_download()` without waiting for approval.

Move the confirmation gate outside the metadata block so `-p` always requires an explicit `y` or `Y` before continuing. Metadata reporting remains conditional, while EOF and other responses cancel the operation.
